### PR TITLE
Handle shortcode rendering

### DIFF
--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -45,6 +45,8 @@ class Shortcode_UI {
 
 		$args['shortcode'] = $shortcode;
 
+		add_shortcode( $shortcode, array( $this, 'render_shortcode' ) );
+
 		$this->shortcodes[ $shortcode ] = $args;
 
 	}
@@ -119,6 +121,7 @@ class Shortcode_UI {
 		}
 
 		extract( $template_args, EXTR_SKIP );
+
 		ob_start();
 		include $template_file;
 
@@ -127,6 +130,22 @@ class Shortcode_UI {
 		}
 
 		echo ob_get_clean();
+
+	}
+
+	function render_shortcode( $atts, $content = null, $shortcode ) {
+
+		if ( ! array_key_exists( $shortcode, $this->shortcodes ) ) {
+			return;
+		}
+
+		$args            = $this->shortcodes[ $shortcode ];
+		$atts['content'] = $content;
+		$atts            = apply_filters( "shortcode_ui_render_atts_$shortcode", $atts );
+
+		if ( $args['templateRender'] ) {
+			return $this->get_view( $args['templateRender'], $atts, false );
+		}
 
 	}
 

--- a/inc/templates/shortcode-blockquote-ui-render.tpl.php
+++ b/inc/templates/shortcode-blockquote-ui-render.tpl.php
@@ -1,0 +1,10 @@
+<blockquote>
+
+	<?php echo esc_html( $content ); ?>
+
+	<?php if ( ! empty( $source ) ) : ?>
+		<small>By <?php echo esc_html( $source ); ?></small>
+	<?php endif; ?>
+
+</blockquote>
+


### PR DESCRIPTION
Should the scope of this plugin extend to handling add_shortcode and the callback?
- Big + is that we can use the same templates internally.
- Bad - Not such good compat with existing shortcodes.

Could make this optional - eg if render template is provided then can specify render callback? What if they add shortcode too? maybe modify `$shortcode_tags[$tag]` directly?

I would like to keep options to a minimum and would like to have a certain ammount of backwards compat if a user chooses to move away from this plugin.
