### PR TITLE
Tweaks from Daniel's code review

### DIFF
--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -32,16 +32,16 @@ class Shortcode_UI {
 		} );
 
 		add_action( 'media_buttons',         array( $this, 'action_media_buttons' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-		add_action( 'print_media_templates', array( $this, 'print_templates' ) );
-		add_action( 'wp_ajax_do_shortcode',  array( $this, 'ajax_do_shortcode' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'action_admin_enqueue_scripts' ) );
+		add_action( 'print_media_templates', array( $this, 'action_print_media_templates' ) );
+		add_action( 'wp_ajax_do_shortcode',  array( $this, 'handle_ajax_do_shortcode' ) );
 	}
 
 	private function setup_filters() {
 		add_filter( 'tiny_mce_before_init',  array( $this, 'modify_tiny_mce_4' ) );
 	}
 
-	function register_shortcode_ui( $shortcode_tag, $args = array() ) {
+	public function register_shortcode_ui( $shortcode_tag, $args = array() ) {
 
 		$defaults = array(
 			'label'         => '',
@@ -63,7 +63,7 @@ class Shortcode_UI {
 
 	}
 
-	function get_shortcode( $shortcode_tag ) {
+	public function get_shortcode( $shortcode_tag ) {
 
 		if ( isset( $this->shortcodes[ $shortcode_tag ] ) ) {
 			return $this->shortcodes[ $shortcode_tag ];
@@ -103,7 +103,7 @@ class Shortcode_UI {
 
 	}
 
-	function enqueue_scripts( $hook ) {
+	public function action_admin_enqueue_scripts( $hook ) {
 
     	if ( in_array( $hook, array( 'post.php', 'post-new.php' ) ) ) {
 
@@ -126,7 +126,7 @@ class Shortcode_UI {
 	 *
 	 * @return null
 	 */
-	public function print_templates() {
+	public function action_print_media_templates() {
 		$this->get_view( 'media-frame' );
 		$this->get_view( 'list-item' );
 		$this->get_view( 'edit-form' );
@@ -173,7 +173,7 @@ class Shortcode_UI {
 	 * @param  array tinyMCE config
 	 * @return array tinyMCE config
 	 */
-	function modify_tiny_mce_4( $init ) {
+	public function modify_tiny_mce_4( $init ) {
 		$init['content_css'] .= ',' . $this->plugin_url . '/css/shortcode-ui-editor-styles.css';
 		return $init;
 	}
@@ -184,7 +184,7 @@ class Shortcode_UI {
 	 *
 	 * @return null
 	 */
-	function ajax_do_shortcode( ) {
+	public function handle_ajax_do_shortcode( ) {
 
 		$shortcode = ! empty( $_POST['shortcode'] ) ? sanitize_text_field( $_POST['shortcode'] ) : null;
 		$post_id   = ! empty( $_POST['post_id'] ) ? intval( $_POST['post_id'] ) : null;

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -12,6 +12,8 @@ class Shortcode_UI {
 	public static function get_instance() {
 		if ( null == self::$instance ) {
 			self::$instance = new self;
+			self::$instance->setup_actions();
+			self::$instance->setup_filters();
 		}
 		return self::$instance;
 	}
@@ -22,6 +24,9 @@ class Shortcode_UI {
 		$this->plugin_dir     = plugin_dir_path( dirname(  __FILE__ ) );
 		$this->plugin_url     = plugin_dir_url( dirname( __FILE__ ) );
 
+	}
+
+	private function setup_actions() {
 		add_action( 'admin_init', function() {
 			remove_action( 'media_buttons', 'media_buttons' );
 		} );
@@ -29,9 +34,11 @@ class Shortcode_UI {
 		add_action( 'media_buttons',         array( $this, 'action_media_buttons' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		add_action( 'print_media_templates', array( $this, 'print_templates' ) );
-		add_filter( 'tiny_mce_before_init',  array( $this, 'modify_tiny_mce_4' ) );
 		add_action( 'wp_ajax_do_shortcode',  array( $this, 'ajax_do_shortcode' ) );
+	}
 
+	private function setup_filters() {
+		add_filter( 'tiny_mce_before_init',  array( $this, 'modify_tiny_mce_4' ) );
 	}
 
 	function register_shortcode_ui( $shortcode_tag, $args = array() ) {

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -98,26 +98,25 @@ class Shortcode_UI {
 			$id_attribute,
 			esc_attr( $editor_id ),
 			esc_attr__( 'Add Content', 'shortcode-ui' ),
-			$img . __( 'Add Content', 'shortcode-ui' )
+			$img . esc_html__( 'Add Content', 'shortcode-ui' )
 		);
 
 	}
 
 	public function action_admin_enqueue_scripts( $hook ) {
 
-    	if ( in_array( $hook, array( 'post.php', 'post-new.php' ) ) ) {
+		if ( in_array( $hook, array( 'post.php', 'post-new.php' ) ) ) {
 
-    		wp_enqueue_script( 'shortcode-ui', $this->plugin_url . 'js/shortcode-ui.js', array( 'jquery', 'backbone', 'mce-view' ), $this->plugin_version );
-    		wp_enqueue_style( 'shortcode-ui', $this->plugin_url . 'css/shortcode-ui.css', array(), $this->plugin_version );
-
-    		wp_localize_script( 'shortcode-ui', ' shortcodeUIData', array(
-    			'shortcodes' => array_values( $this->shortcodes ),
-    			'modalOptions' => array(
-    				'media_frame_title' => 'Insert Content Item',
+			wp_enqueue_script( 'shortcode-ui', $this->plugin_url . 'js/shortcode-ui.js', array( 'jquery', 'backbone', 'mce-view' ), $this->plugin_version );
+			wp_enqueue_style( 'shortcode-ui', $this->plugin_url . 'css/shortcode-ui.css', array(), $this->plugin_version );
+			wp_localize_script( 'shortcode-ui', ' shortcodeUIData', array(
+				'shortcodes' => array_values( $this->shortcodes ),
+    				'modalOptions' => array(
+    					'media_frame_title' => esc_html__( 'Insert Content Item', 'shortcode-ui' ),
 				)
-    		) );
+			) );
 
-    	}
+		}
 
 	}
 

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -111,7 +111,8 @@ class Shortcode_UI {
 			wp_enqueue_style( 'shortcode-ui', $this->plugin_url . 'css/shortcode-ui.css', array(), $this->plugin_version );
 			wp_localize_script( 'shortcode-ui', ' shortcodeUIData', array(
 				'shortcodes' => array_values( $this->shortcodes ),
-    				'modalOptions' => array(
+				'previewNonce' => wp_create_nonce( 'shortcode-ui-preview' ),
+				'modalOptions' => array(
     					'media_frame_title' => esc_html__( 'Insert Content Item', 'shortcode-ui' ),
 				)
 			) );
@@ -181,6 +182,11 @@ class Shortcode_UI {
 
 		$shortcode = ! empty( $_POST['shortcode'] ) ? sanitize_text_field( $_POST['shortcode'] ) : null;
 		$post_id   = ! empty( $_POST['post_id'] ) ? intval( $_POST['post_id'] ) : null;
+
+		if ( ! current_user_can( 'edit_post', $post_id ) || ! wp_verify_nonce( $_POST['nonce'], 'shortcode-ui-preview' ) ) {
+			echo esc_html__( "Something's rotten in the state of Denmark", 'shortcode-ui' );
+			exit;
+		}
 
 		global $post;
 		$post = get_post( $post_id );

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -127,9 +127,9 @@ class Shortcode_UI {
 	 * @return null
 	 */
 	public function action_print_media_templates() {
-		$this->get_view( 'media-frame' );
-		$this->get_view( 'list-item' );
-		$this->get_view( 'edit-form' );
+		echo $this->get_view( 'media-frame' );
+		echo $this->get_view( 'list-item' );
+		echo $this->get_view( 'edit-form' );
 	}
 
 	/**
@@ -138,10 +138,9 @@ class Shortcode_UI {
 	 *
 	 * @param  string  $template      full template file path. Or name of template file in inc/templates.
 	 * @param  array   $template_args array of args
-	 * @param  boolean $echo          [description]
 	 * @return [type]                 [description]
 	 */
-	public function get_view( $template, $template_args = array(), $echo = true ) {
+	public function get_view( $template, $template_args = array() ) {
 
 		if ( ! file_exists( $template ) ) {
 
@@ -159,12 +158,7 @@ class Shortcode_UI {
 		ob_start();
 		include $template;
 
-		if ( ! $echo ) {
-			return ob_get_clean();
-		}
-
-		echo ob_get_clean();
-
+		return ob_get_clean();
 	}
 
 	/**

--- a/js/shortcode-ui.js
+++ b/js/shortcode-ui.js
@@ -477,7 +477,8 @@ var Shortcode_UI;
 					data = {
 						action: 'do_shortcode',
 						post_id: $('#post_ID').val(),
-						shortcode: this.shortcode.formatShortcode()
+						shortcode: this.shortcode.formatShortcode(),
+						nonce: shortcodeUIData.previewNonce
 					};
 
 					$.post( ajaxurl, data, function( response ) {

--- a/shortcode-ui.php
+++ b/shortcode-ui.php
@@ -19,7 +19,7 @@
  * GNU General Public License for more details.
  */
 
-require_once( 'inc/class-shortcode-ui.php' );
+require_once dirname( __FILE__ ) . '/inc/class-shortcode-ui.php';
 
 add_action( 'init', function() {
 	$instance = Shortcode_UI::get_instance();


### PR DESCRIPTION
- Nonce / caps check for shortcode previews. Fixes #15
- Mark methods as public; rename some to be more explicit.
- Fix odd double nature of `get_view()`. Fixes #11
- Proper escaping of translation functions.
- Formatting
