### PR TITLE
Fieldmanager

### DIFF
--- a/dev.php
+++ b/dev.php
@@ -9,12 +9,19 @@ add_action( 'init', function() {
 	add_shortcode( 'pullquote', function( $attr, $content = '' ) {
 
 		$attr = wp_parse_args( $attr, array(
-			'source' => ''
+			'source' => '',
+			'image'  => '',
 		) );
 
 		?>
 
-		<section class="pullquote">
+		<section class="pullquote" style="overflow: hidden;">
+			<?php if ( $attr['image'] ) : ?>
+			<div style="float: left; margin-right: 20px;">
+				<?php echo wp_get_attachment_image( $attr['image'], array( 112, 112 ) ); ?>
+			</div>
+			<?php endif; ?>
+
 			<?php echo esc_html( $content ); ?><br/>
 			<cite><em><?php echo esc_html( $attr['source'] ); ?></em></cite>
 		</section>

--- a/dev.php
+++ b/dev.php
@@ -41,16 +41,26 @@ add_action( 'init', function() {
 			// Attribute model expects 'attr', 'type' and 'label'
 			// Supported field types: 'text', 'url', 'textarea', 'select'
 			'attrs' => array(
+
 				array(
 					'label' => 'Quote',
 					'attr'  => 'content',
-					'type'  => 'textarea',
+					'type'  => 'Fieldmanager_TextArea',
 				),
+
+				array(
+					'label' => 'Image',
+					'attr'  => 'image',
+					'type'  => 'Fieldmanager_Media',
+					'fieldView' => 'editAttributeFieldMedia',
+				),
+
 				array(
 					'label' => 'Cite',
 					'attr'  => 'source',
-					'type'  => 'text',
+					'type'  => 'Fieldmanager_Textfield',
 				),
+
 			),
 		)
 	);

--- a/inc/class-fieldmanager-fields.php
+++ b/inc/class-fieldmanager-fields.php
@@ -1,0 +1,72 @@
+<?php
+
+
+class Shortcode_UI_Fieldmanager_Fields {
+
+	static $instance;
+
+	private $fields = array(
+		'Fieldmanager_Textfield',
+		'Fieldmanager_TextArea',
+		'Fieldmanager_Media'
+	);
+
+	public static function get_instance() {
+		if ( null == self::$instance ) {
+			self::$instance = new self;
+			self::$instance->setup_actions();
+		}
+		return self::$instance;
+	}
+
+	function setup_actions() {
+		$this->init();
+		add_action( 'wp_ajax_shortcode_ui_get_thumbnail_image', array( $this, 'ajax_get_thumbnail_image' ) );
+	}
+
+	function init() {
+
+		foreach ( $this->fields as $field_class ) {
+
+			$field = new $field_class( '{{ data.label }}', array( 'name' => '{{ data.attr }}' ) );
+
+			add_action( 'print_media_templates', function() use ( $field_class, $field ) {
+
+				printf(
+					'<script type="text/html" id="tmpl-shortcode-ui-field-%s">',
+					$field_class
+				);
+
+				echo $field->element_markup( '{{ data.value }}' );
+				echo "</script>\r";
+
+			} );
+
+		}
+
+	}
+
+	function ajax_get_thumbnail_image() {
+
+		if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( $_POST['nonce'], 'shortcode-ui-get-thumbnail-image' ) ) {
+			wp_send_json_error();
+		}
+
+		$id    = intval( $_POST['id'] );
+		$size  = sanitize_text_field( $_POST['size'] );
+		$image = wp_get_attachment_image_src( $id, $size );
+
+		if ( ! $image ) {
+			wp_send_json_error();
+		}
+
+		wp_send_json_success( array(
+			'src'    => $image[0],
+			'width'  => $image[1],
+			'height' => $image[2],
+			'html'   => wp_get_attachment_image( $id, $size ),
+		) );
+
+	}
+
+}

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -111,9 +111,12 @@ class Shortcode_UI {
 			wp_enqueue_style( 'shortcode-ui', $this->plugin_url . 'css/shortcode-ui.css', array(), $this->plugin_version );
 			wp_localize_script( 'shortcode-ui', ' shortcodeUIData', array(
 				'shortcodes' => array_values( $this->shortcodes ),
-				'previewNonce' => wp_create_nonce( 'shortcode-ui-preview' ),
 				'modalOptions' => array(
-    					'media_frame_title' => esc_html__( 'Insert Content Item', 'shortcode-ui' ),
+    				'media_frame_title' => esc_html__( 'Insert Content Item', 'shortcode-ui' ),
+				),
+				'nonces' => array(
+					'preview'        => wp_create_nonce( 'shortcode-ui-preview' ),
+					'thumbnailImage' => wp_create_nonce( 'shortcode-ui-get-thumbnail-image' ),
 				)
 			) );
 

--- a/js/shortcode-ui.js
+++ b/js/shortcode-ui.js
@@ -231,51 +231,6 @@ var Shortcode_UI;
 
 	} );
 
-	sui.views.editAttributeFieldMedia = sui.views.editAttributeField.extend( {
-
-		events: {},
-
-		render: function() {
-
-			this.template = wp.media.template( 'shortcode-ui-field-' + this.model.get( 'type' ) );
-			var html = $( this.template( this.model.toJSON() ) );
-
-			// Define preview size for use by fieldmanager JS.
-			window.fm_preview_size = window.fm_preview_size || [];
-			window.fm_preview_size[ this.model.get('attr') ] = 'thumbnail';
-
-			// Create template if neccessary.
-			if ( this.model.get('value') ) {
-
-				var data = {
-					action: 'shortcode_ui_get_thumbnail_image',
-					id: this.model.get('value'),
-					size: 'thumbnail',
-					nonce: shortcodeUIData.nonces.thumbnailImage
-				};
-
-				$.post( ajaxurl, data, function(response) {
-
-					if ( ! response.success ) {
-						return;
-					}
-
-					var previewHTML = 'Uploaded file:</br>';
-					previewHTML += '<a href="#">' + response.data.html + '</a></br>';
-					previewHTML += '<a class="fm-media-remove fm-delete" href="#">remove</a>';
-					html.find('.media-wrapper').append( previewHTML );
-
-				});
-
-			}
-
-			return this.$el.html( html );
-
-		},
-
-	} );
-
-
 	sui.views.Shortcode_UI = wp.Backbone.View.extend({
 
 		events: {
@@ -304,6 +259,7 @@ var Shortcode_UI;
 		},
 
 		renderSelectShortcodeView: function() {
+			this.views.unset();
 			this.views.add(
 				'',
 				new sui.views.insertShortcodeList( { shortcodes: sui.shortcodes } )
@@ -316,6 +272,7 @@ var Shortcode_UI;
 				model:  this.controller.props.get( 'currentShortcode' ),
 			} );
 
+			this.views.unset();
 			this.views.add( '', view );
 
 			if ( this.controller.props.get('action') === 'update' ) {

--- a/shortcode-ui.php
+++ b/shortcode-ui.php
@@ -20,9 +20,17 @@
  */
 
 require_once dirname( __FILE__ ) . '/inc/class-shortcode-ui.php';
+require_once dirname( __FILE__ ) . '/inc/class-fieldmanager-fields.php';
+require_once dirname( __FILE__ ) . '/dev.php';
 
 add_action( 'init', function() {
+
 	$instance = Shortcode_UI::get_instance();
+
+	if ( class_exists( 'Fieldmanager_Field' ) ) {
+		$shortcode_ui_fieldmanager = Shortcode_UI_Fieldmanager_Fields::get_instance();
+	}
+
 }, 5 );
 
 /**


### PR DESCRIPTION
**NOTE:** This is still in progress.

Integration with fieldnamager to build out fields.

Here's where i'm at so far - and my thoughts on this.

Added fieldnamager firlds for textarea, text and media.

**The good:** 

We have a funcitoning fields - including image upload field.

I have made the core code for displaying fields more customisable - allowing developers to specify both a template for each field, and also a custom view object - which can be used to build more complex field types such as media uploader. This means the fieldmanager code can live as a compeltely separate 'plugin'.

The basic fieldmanager fields worked really well just by passing the underscore template placeholders as label, value and ID.

*\* The Bad**
More complex fields like the media uploader don't really work so well out of the box. Media for example requires a few workarounds to make th JS work correctly, and update the values.

Example 1: select field. We don't have access to options when building the template. So it requries custom JS to add these.

Example 2:  media field preview image HTML isn't output in the template because we have no value at this point. I have hacked around this by using ajax to get the image src and replicating the markup required - but its hacky.

My concerns here are we do not get enough benefit from fieldmanager. If custom code is required for  each of the more complex fields - is it that much easier than building our own? Basically fieldmanager is PHP and Shortcake is JS and its hacky to mesh the two. 

Also by going too far down this route are we making fieldmanager a dependency which would put people off using Shortcake?

Any thoughts?
