### PR TITLE
Existing shortcodes without attributes should work

### DIFF
--- a/js/shortcode-ui.js
+++ b/js/shortcode-ui.js
@@ -113,7 +113,7 @@ var Shortcode_UI;
 			}
 
 			template = template.replace( /{{ shortcode }}/g, this.get('shortcode_tag') );
-            template = template.replace( /{{ attributes }}/g, attrs.join( ' ' ) );
+			template = template.replace( /{{ attributes }}/g, attrs.join( ' ' ) );
 			template = template.replace( /{{ content }}/g, content );
 
 			return template;

--- a/js/shortcode-ui.js
+++ b/js/shortcode-ui.js
@@ -113,7 +113,7 @@ var Shortcode_UI;
 			}
 
 			template = template.replace( /{{ shortcode }}/g, this.get('shortcode_tag') );
-			template = template.replace( /{{ attributes }}/g, attrs.join( ' ' ) );
+            template = template.replace( /{{ attributes }}/g, attrs.join( ' ' ) );
 			template = template.replace( /{{ content }}/g, content );
 
 			return template;
@@ -666,7 +666,7 @@ var Shortcode_UI;
 
 			shortcodeString = decodeURIComponent( $(node).attr( 'data-wpview-text' ) );
 
-			var megaRegex = /\[(\S+)([^\]]+)?\]([^\[]*)?(\[\/(\S+?)\])?/;
+			var megaRegex = /\[([^\s\]]+)([^\]]+)?\]([^\[]*)?(\[\/(\S+?)\])?/;
 			var matches = shortcodeString.match( megaRegex );
 
 			if ( ! matches ) {
@@ -681,7 +681,7 @@ var Shortcode_UI;
 
 			currentShortcode = defaultShortcode.clone();
 
-			if ( typeof( matches[2] ) != undefined ) {
+			if ( matches[2] ) {
 
 				attributeMatches = matches[2].match(/(\S+?=".*?")/g ) || [];
 


### PR DESCRIPTION
In issue #50 pre-existing shortcodes weren't matching the regex, take the following:

```
[pullquote]4 score and 7...[/pullquote]
```

The shortcode tag was matched as `pullquote]4`.

I made the match for non white space and no closing square brackets. Also the test for `matches[2]` was always coming back true as you can't use the `!=` operator with undefined.
