### PR TITLE
Fix fieldmanager media field

### DIFF
--- a/inc/fields/class-shortcode-ui-fields-fieldmanager.php
+++ b/inc/fields/class-shortcode-ui-fields-fieldmanager.php
@@ -144,7 +144,8 @@ class Shortcode_UI_Fields_Fieldmanager {
 			}
 
 			/**
-			 * Update the value when media iframe is closed.
+			 * Update the value when media iframe is closed,
+			 * setTimeout() is used to wait for the iframe to be created
 			 */
 			var self   = this;
 			var button = html.find( '.fm-media-button' );

--- a/inc/fields/class-shortcode-ui-fields-fieldmanager.php
+++ b/inc/fields/class-shortcode-ui-fields-fieldmanager.php
@@ -143,6 +143,20 @@ class Shortcode_UI_Fields_Fieldmanager {
 
 			}
 
+			/**
+			 * Update the value when media iframe is closed.
+			 */
+			var self   = this;
+			var button = html.find( '.fm-media-button' );
+			button.on( 'click', function() {
+				window.setTimeout( function() {
+					fm_media_frame[ button.attr('id') ].on( 'select', function() {
+						var $el = self.$el.find( '.fm-media-id' );
+						self.model.set( 'value', $el.val() );
+					} );
+				}, 100 );
+			} );
+
 			return this.$el.html( html );
 
 		},


### PR DESCRIPTION
Fieldmanager media field is broken.

The cause is that the JS programatically updates the hidden input field, and the normal events that trigger the updating of the model don't fire.

So we need to do this manually - when the frame is closed. This is a little hacky in that we have to wait for the frame to be created before attaching the event - hence the setTimeout - but it works!

Review & Merge cc @danielbachhuber 
