### PR TITLE
Re-Render after removing image

### DIFF
--- a/inc/fields/class-shortcode-ui-fields-fieldmanager.php
+++ b/inc/fields/class-shortcode-ui-fields-fieldmanager.php
@@ -107,6 +107,7 @@ class Shortcode_UI_Fields_Fieldmanager {
 
 		events: {
 			'click .fm-media-button': 'reorderModals',
+			'click .fm-media-remove': 'render',
 		},
 
 		render: function() {


### PR DESCRIPTION
see #83 

And easy fix here is to re-render the field after an image is removed. This means the 'attach file' button works again after an image is removed.
