### PR TITLE
Remove conflict with ACF Pro

### DIFF
--- a/js/shortcode-ui.js
+++ b/js/shortcode-ui.js
@@ -1075,14 +1075,14 @@ var Shortcode_UI;
 		sui.shortcodes = new sui.collections.Shortcodes( shortcodeUIData.shortcodes )
 
 		sui.shortcodes.each( function( shortcode ) {
-
-			// Register the mce view for each shortcode.
-			// Note - clone the constructor.
-			wp.mce.views.register(
-				shortcode.get('shortcode_tag'),
-				$.extend( true, {}, sui.utils.shortcodeViewConstructor )
-			);
-
+			if( wp.mce ) {
+				// Register the mce view for each shortcode.
+				// Note - clone the constructor.
+				wp.mce.views.register(
+					shortcode.get('shortcode_tag'),
+					$.extend( true, {}, sui.utils.shortcodeViewConstructor )
+				);
+			}
 		} );
 
 	});

--- a/js/shortcode-ui.js
+++ b/js/shortcode-ui.js
@@ -1075,7 +1075,7 @@ var Shortcode_UI;
 		sui.shortcodes = new sui.collections.Shortcodes( shortcodeUIData.shortcodes )
 
 		sui.shortcodes.each( function( shortcode ) {
-			if( wp.mce ) {
+			if( wp.mce.views ) {
 				// Register the mce view for each shortcode.
 				// Note - clone the constructor.
 				wp.mce.views.register(


### PR DESCRIPTION
From what I can tell Advanced Custom Fields doesn't create the default (or any) TinyMCE instance that `wp.mce.views.register` attempts to use.

This is almost too simple a fix, but it seems to work fine on all my installs.  I pasted it in https://github.com/fusioneng/Shortcake/issues/90 last month, but I thought I should create a pull request to at least try to give back.
