### PR TITLE
Only load Shortcode UI assets when TinyMCE has loaded

### DIFF
--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -29,6 +29,7 @@ class Shortcode_UI {
 		add_action( 'after_setup_theme',     array( $this, 'action_after_setup_theme' ) );
 		add_action( 'wp_enqueue_editor',     array( $this, 'action_wp_enqueue_editor' ) );
 		add_action( 'wp_ajax_do_shortcode',  array( $this, 'handle_ajax_do_shortcode' ) );
+		add_action( 'print_media_templates', array( $this, 'action_print_media_templates' ) );
 	}
 
 	public function register_shortcode_ui( $shortcode_tag, $args = array() ) {
@@ -89,8 +90,6 @@ class Shortcode_UI {
 				'thumbnailImage' => wp_create_nonce( 'shortcode-ui-get-thumbnail-image' ),
 			)
 		) );
-
-		add_action( 'print_media_templates', array( $this, 'action_print_media_templates' ) );
 
 		do_action( 'shortcode_ui_loaded_editor' );
 

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -27,8 +27,7 @@ class Shortcode_UI {
 
 	private function setup_actions() {
 		add_action( 'after_setup_theme',     array( $this, 'action_after_setup_theme' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'action_admin_enqueue_scripts' ) );
-		add_action( 'print_media_templates', array( $this, 'action_print_media_templates' ) );
+		add_action( 'wp_enqueue_editor',     array( $this, 'action_wp_enqueue_editor' ) );
 		add_action( 'wp_ajax_do_shortcode',  array( $this, 'handle_ajax_do_shortcode' ) );
 	}
 
@@ -70,30 +69,30 @@ class Shortcode_UI {
 		add_editor_style($this->plugin_url . '/css/shortcode-ui-editor-styles.css');
 	}
 
-	public function action_admin_enqueue_scripts( $hook ) {
+	public function action_wp_enqueue_editor() {
 
-		if ( in_array( $hook, array( 'post.php', 'post-new.php' ) ) ) {
+		wp_enqueue_script( 'shortcode-ui', $this->plugin_url . 'js/shortcode-ui.js', array( 'jquery', 'backbone', 'mce-view' ), $this->plugin_version );
+		wp_enqueue_style( 'shortcode-ui', $this->plugin_url . 'css/shortcode-ui.css', array(), $this->plugin_version );
+		wp_localize_script( 'shortcode-ui', ' shortcodeUIData', array(
+			'shortcodes' => array_values( $this->shortcodes ),
+			'modalOptions' => array(
+					'media_frame_title'              => esc_html__( 'Insert Post Element', 'shortcode-ui' ),
+					'media_frame_menu_insert_label'  => esc_html__( 'Insert Post Element', 'shortcode-ui' ),
+					'media_frame_menu_update_label'  => esc_html__( 'Post Element Details', 'shortcode-ui' ),
+					'media_frame_toolbar_insert_label' => esc_html__( 'Insert Element', 'shortcode-ui' ),
+					'media_frame_toolbar_update_label' => esc_html__( 'Update', 'shortcode-ui' ),
+					'edit_tab_label'                 => esc_html__( 'Edit', 'shortcode-ui' ),
+					'preview_tab_label'	             => esc_html__( 'Preview', 'shortcode-ui' )
+			),
+			'nonces' => array(
+				'preview'        => wp_create_nonce( 'shortcode-ui-preview' ),
+				'thumbnailImage' => wp_create_nonce( 'shortcode-ui-get-thumbnail-image' ),
+			)
+		) );
 
-			wp_enqueue_script( 'shortcode-ui', $this->plugin_url . 'js/shortcode-ui.js', array( 'jquery', 'backbone', 'mce-view' ), $this->plugin_version );
-			wp_enqueue_style( 'shortcode-ui', $this->plugin_url . 'css/shortcode-ui.css', array(), $this->plugin_version );
-			wp_localize_script( 'shortcode-ui', ' shortcodeUIData', array(
-				'shortcodes' => array_values( $this->shortcodes ),
-				'modalOptions' => array(
-						'media_frame_title'              => esc_html__( 'Insert Post Element', 'shortcode-ui' ),
-						'media_frame_menu_insert_label'  => esc_html__( 'Insert Post Element', 'shortcode-ui' ),
-						'media_frame_menu_update_label'  => esc_html__( 'Post Element Details', 'shortcode-ui' ),
-						'media_frame_toolbar_insert_label' => esc_html__( 'Insert Element', 'shortcode-ui' ),
-						'media_frame_toolbar_update_label' => esc_html__( 'Update', 'shortcode-ui' ),
-						'edit_tab_label'	             => esc_html__( 'Edit', 'shortcode-ui' ),
-						'preview_tab_label'	             => esc_html__( 'Preview', 'shortcode-ui' )
-				),
-				'nonces' => array(
-					'preview'        => wp_create_nonce( 'shortcode-ui-preview' ),
-					'thumbnailImage' => wp_create_nonce( 'shortcode-ui-get-thumbnail-image' ),
-				)
-			) );
+		add_action( 'print_media_templates', array( $this, 'action_print_media_templates' ) );
 
-		}
+		do_action( 'shortcode_ui_loaded_editor' );
 
 	}
 

--- a/inc/fields/class-shortcode-ui-fields-fieldmanager.php
+++ b/inc/fields/class-shortcode-ui-fields-fieldmanager.php
@@ -27,15 +27,18 @@ class Shortcode_UI_Fields_Fieldmanager {
 
 	private function setup_actions() {
 
-		$this->initialize_templates();
-
 		add_filter( 'shortcode_ui_fields', function( $fields ) {
 			return array_merge( $fields, $this->fields );
 		}  );
 
-		add_action( 'print_media_templates', array( $this, 'action_print_media_templates' ), 100 );
+		add_action( 'shortcode_ui_loaded_editor', array( $this, 'action_shortcode_ui_loaded_editor' ) );
 		add_action( 'wp_ajax_shortcode_ui_get_thumbnail_image', array( $this, 'ajax_get_thumbnail_image' ) );
 
+	}
+
+	public function action_shortcode_ui_loaded_editor() {
+		add_action( 'print_media_templates', array( $this, 'action_print_media_templates' ), 100 );
+		$this->initialize_templates();
 	}
 
 	private function initialize_templates() {

--- a/inc/fields/class-shortcode-ui-fields.php
+++ b/inc/fields/class-shortcode-ui-fields.php
@@ -49,7 +49,7 @@ class Shortcode_UI_Fields {
 
 	private function setup_actions() {
 		add_action( 'init', array( $this, 'action_init' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'action_admin_enqueue_scripts' ), 100 );
+		add_action( 'shortcode_ui_loaded_editor', array( $this, 'action_shortcode_ui_loaded_editor' ), 100 );
 	}
 
 	/**
@@ -70,7 +70,7 @@ class Shortcode_UI_Fields {
 
 	}
 
-	public function action_admin_enqueue_scripts() {
+	public function action_shortcode_ui_loaded_editor() {
 
 		wp_localize_script( 'shortcode-ui', 'shortcodeUIFieldData', $this->fields );
 


### PR DESCRIPTION
Shortcode UI provides a visual representation of shortcodes within TinyMCE. This will prevent our code from loading elsewhere

Introduces a new `shortcode_ui_loaded_editor` action for third-parties to depend on

See #109, #90
