### PR TITLE
Only refresh toolbar when the frame is defined

### DIFF
--- a/js/shortcode-ui.js
+++ b/js/shortcode-ui.js
@@ -658,7 +658,9 @@ var Shortcode_UI;
 
 		refresh: function() {
 			// @todo Need to trigger disabled state on button.
-			this.frame.toolbar.get().refresh();
+			if ( this.frame ) {
+				this.frame.toolbar.get().refresh();
+			}
 		},
 
 		insert: function() {


### PR DESCRIPTION
Prevents JS error when the frame isn't yet open

Fixes #151
