### PR TITLE
Fix JS error when attribute doesn't have `type`

### DIFF
--- a/js/shortcode-ui.js
+++ b/js/shortcode-ui.js
@@ -439,7 +439,7 @@ var Shortcode_UI;
 		 */
 		updateValue: function( e ) {
 			var $el = $(this.el).find( '[name=' + this.model.get( 'attr' ) + ']' );
-			if ( $el.attr( 'type' ).toLowerCase() == 'checkbox' ) {
+			if ( $el.attr( 'type' ).length && $el.attr( 'type' ).toLowerCase() == 'checkbox' ) {
 				this.model.set( 'value', $el.is( ':checked' ) );
 			} else {
 				this.model.set( 'value', $el.val() );


### PR DESCRIPTION
From #150
