### PR TITLE
167 - preview completely broken

### DIFF
--- a/js/shortcode-ui.js
+++ b/js/shortcode-ui.js
@@ -476,7 +476,7 @@ var Shortcode_UI;
 			self.renderIFrame({ body: wp.mce.View.prototype.loadingPlaceholder(), head: stylesheets });
 
 			this.fetchShortcode( function( result ) {
-				self.renderIFrame({ body: result, head: stylesheets });
+				self.renderIFrame({ body: result.data, head: stylesheets });
 			});
 
 			return this;


### PR DESCRIPTION
`do_shortcode` ajax request was changed to use `wp_send_json_success` to return the data. This means that the response is now an object with the HTML string passed as the data property.

The preview was not updated accordingly.

Fixes #167
