### PR TITLE
Do template after default args are set so default args are applied

### DIFF
--- a/js/field-attachment.js
+++ b/js/field-attachment.js
@@ -9,17 +9,16 @@
 
 		render: function() {
 
-			this.$el.html( this.template( this.model.toJSON() ) );
-
 			var model = this.model;
 
 			// Set model default values.
 			for ( var arg in ShorcakeImageFieldData.defaultArgs ) {
-				var currentArg = model.get( arg );
-				if ( ! currentArg ) {
+				if ( ! model.get( arg ) ) {
 					model.set( arg, ShorcakeImageFieldData.defaultArgs[ arg ] );
 				}
 			}
+
+			this.$el.html( this.template( model.toJSON() ) );
 
 			var $container    = this.$el.find( '.shortcake-attachment-preview' );
 			var $addButton    = $container.find( 'button.add' );


### PR DESCRIPTION
The template is being rendered _before_ the default args are set. So if you don't pass a custom string for the add attachment button, the button is empty.

Simple fix - render the template after the default args are set.
