### PR TITLE
93 allow content edit mods 2

### DIFF
--- a/js/shortcode-ui.js
+++ b/js/shortcode-ui.js
@@ -966,13 +966,8 @@ var Shortcode_UI;
 			}
 
 			if ( matches[3] ) {
-				var content = currentShortcode.get( 'attrs' ).findWhere( { attr: 'content' } );
-				if ( content ) {
-					content.set( 'value', matches[3] );
-				} else {
-					var inner_content = currentShortcode.get( 'inner_content' );
-					inner_content.set( 'value', matches[3] );
-				}
+				var inner_content = currentShortcode.get( 'inner_content' );
+				inner_content.set( 'value', matches[3] );
 			}
 
 			var wp_media_frame = wp.media.frames.wp_media_frame = wp.media( {

--- a/js/shortcode-ui.js
+++ b/js/shortcode-ui.js
@@ -165,7 +165,11 @@ var Shortcode_UI;
 			if ( attributes.attrs !== undefined && ! ( attributes.attrs instanceof sui.models.ShortcodeAttributes ) ) {
 				attributes.attrs = new sui.models.ShortcodeAttributes( attributes.attrs );
 			}
-			
+
+			if ( attributes.inner_content !== undefined && ! ( attributes.inner_content instanceof sui.models.InnerContent ) ) {
+				attributes.inner_content = new sui.models.InnerContent( attributes.inner_content );
+			}
+
 			return Backbone.Model.prototype.set.call(this, attributes, options);
 		},
 
@@ -174,10 +178,17 @@ var Shortcode_UI;
 		 * Handles converting the attribute collection to JSON.
 		 */
 		toJSON: function( options ) {
+
 			options = Backbone.Model.prototype.toJSON.call(this, options);
+
 			if ( options.attrs !== undefined && ( options.attrs instanceof sui.models.ShortcodeAttributes ) ) {
 				options.attrs = options.attrs.toJSON();
 			}
+
+			if ( options.inner_content !== undefined && ( options.inner_content instanceof sui.models.InnerContent ) ) {
+				options.inner_content = options.inner_content.toJSON();
+			}
+
 			return options;
 		},
 
@@ -188,6 +199,7 @@ var Shortcode_UI;
 		clone: function() {
 			var clone = Backbone.Model.prototype.clone.call( this );
 			clone.set( 'attrs', clone.get( 'attrs' ).clone() );
+			clone.set( 'inner_content', clone.get( 'inner_content' ).clone() );
 			return clone;
 		},
 

--- a/js/shortcode-ui.js
+++ b/js/shortcode-ui.js
@@ -873,24 +873,11 @@ var Shortcode_UI;
 							options.shortcode.attrs.named[ attr.get( 'attr') ]
 						);
 					}
-					
-/*					if ( attr.get( 'attr' ) === 'content' && ( 'content' in options.shortcode ) ) {
-						var temp_content = [];
-						for ( props in attr.attributes ) {
-							if( props === 'attr') {
-								continue;
-							}
-							temp_content[props] == attr.attributes[props];
-						}
-						temp_content['value'] = options.shortcode.content ;
-						shortcode.set( 'inner_content', new sui.models.InnerContent( temp_content ) );
-					}*/
 
 				});
-				
+
 				if ( 'content' in options.shortcode ) {
 					var inner_content = shortcode.get( 'inner_content' );
-					console.log( inner_content );
 					inner_content.set( 'value', options.shortcode.content )
 				}
 

--- a/js/shortcode-ui.js
+++ b/js/shortcode-ui.js
@@ -414,7 +414,7 @@ var Shortcode_UI;
 				var viewObjName = 'editAttributeField';
 				var tmplName    = 'shortcode-ui-field-textarea';
 	
-				var view        = new sui.views[viewObjName]( { model: this.get( 'inner_content' ) } );
+				var view        = new sui.views[viewObjName]( { model: this.model.get( 'inner_content' ) } );
 				view.template   = wp.media.template( tmplName );
 				view.shortcode = t.model;
 	


### PR DESCRIPTION
Couple of issues.
- When creating a model and passing it an object for inner_content, we need to convert this to a proper InnerContent model. Also handle toJSON and clone.
- Trying to call get on `this` not `this.model`
- Removed code to get content attribute data. Is this to handle backwards compatability? I think if we handle it in PHP when defining args, then it will keep the JS neater. What do you think?
