### PR TITLE
Fix fatal error when post is not present

### DIFF
--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -164,9 +164,11 @@ class Shortcode_UI {
 			exit;
 		}
 
-		global $post;
-		$post = get_post( $post_id );
-		setup_postdata( $post );
+		if ( ! empty( $post_id ) ) {
+			global $post;
+			$post = get_post( $post_id );
+			setup_postdata( $post );
+		}
 
 		ob_start();
 		do_action( 'shortcode_ui_before_do_shortcode', $shortcode );


### PR DESCRIPTION
When the visual editor is used outside a post/page, Insert Post Element stops outputting previews. Post data shouldn't really be required to output shortcode previews in the editor.

Fixes: #185 
