### PR TITLE
Fix misnamed variable `Backbonen`

### DIFF
--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -748,7 +748,7 @@ wp.media.view.MediaFrame.Post = shortcodeFrame.extend({
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 },{"./../controllers/media-controller.js":3,"./../utils/sui.js":9,"./shortcode-ui":16,"./toolbar":18}],15:[function(require,module,exports){
 (function (global){
-var Backbonen = (typeof window !== "undefined" ? window.Backbone : typeof global !== "undefined" ? global.Backbone : null);
+var Backbone = (typeof window !== "undefined" ? window.Backbone : typeof global !== "undefined" ? global.Backbone : null);
 
 sui = require('./../utils/sui.js');
 

--- a/js/views/shortcode-preview.js
+++ b/js/views/shortcode-preview.js
@@ -1,4 +1,4 @@
-var Backbonen = require('backbone');
+var Backbone = require('backbone');
 
 sui = require('sui-utils/sui');
 


### PR DESCRIPTION
Having it misnamed doesn't break preview though. Do we need it localized?
