### PR TITLE
use setIframes

### DIFF
--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -369,6 +369,8 @@ var shortcodeViewConstructor = {
 
 	View: {
 
+		overlay: true,
+
 		initialize: function( options ) {
 			this.shortcode = this.getShortcode( options );
 			this.fetch();
@@ -406,124 +408,6 @@ var shortcodeViewConstructor = {
 
 		},
 
-		/**
-		 * Set the HTML. Modeled after wp.mce.View.setIframes
-		 *
-		 * If it includes a script tag, needs to be wrapped in an iframe
-		 */
-		setHtml: function( body ) {
-
-			var MutationObserver = window.MutationObserver || window.WebKitMutationObserver || window.MozMutationObserver;
-
-			if ( body.indexOf( '<script' ) === -1 ) {
-				this.parsed = body;
-				this.render( true );
-				return;
-			}
-
-			this.getNodes( function ( editor, node, content ) {
-				var dom = editor.dom,
-				styles = '',
-				bodyClasses = editor.getBody().className || '',
-				iframe, iframeDoc, i, resize;
-
-				content.innerHTML = '';
-				head = '';
-
-				$(node).addClass('wp-mce-view-show-toolbar');
-
-				if ( ! wp.mce.views.sandboxStyles ) {
-					tinymce.each( dom.$( 'link[rel="stylesheet"]', editor.getDoc().head ), function( link ) {
-						if ( link.href && link.href.indexOf( 'skins/lightgray/content.min.css' ) === -1 &&
-							link.href.indexOf( 'skins/wordpress/wp-content.css' ) === -1 ) {
-
-							styles += dom.getOuterHTML( link ) + '\n';
-						}
-					});
-
-					wp.mce.views.sandboxStyles = styles;
-				} else {
-					styles = wp.mce.views.sandboxStyles;
-				}
-
-				// Seems Firefox needs a bit of time to insert/set the view nodes, or the iframe will fail
-				// especially when switching Text => Visual.
-				setTimeout( function() {
-					iframe = dom.add( content, 'iframe', {
-						src: tinymce.Env.ie ? 'javascript:""' : '',
-						frameBorder: '0',
-						allowTransparency: 'true',
-						scrolling: 'no',
-						'class': 'wpview-sandbox',
-						style: {
-							width: '100%',
-							display: 'block'
-						}
-					} );
-
-					iframeDoc = iframe.contentWindow.document;
-
-					iframeDoc.open();
-					iframeDoc.write(
-						'<!DOCTYPE html>' +
-						'<html>' +
-							'<head>' +
-								'<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />' +
-								head +
-								styles +
-								'<style>' +
-									'html {' +
-										'background: transparent;' +
-										'padding: 0;' +
-										'margin: 0;' +
-									'}' +
-									'body#wpview-iframe-sandbox {' +
-										'background: transparent;' +
-										'padding: 1px 0 !important;' +
-										'margin: -1px 0 0 !important;' +
-									'}' +
-									'body#wpview-iframe-sandbox:before,' +
-									'body#wpview-iframe-sandbox:after {' +
-										'display: none;' +
-										'content: "";' +
-									'}' +
-								'</style>' +
-							'</head>' +
-							'<body id="wpview-iframe-sandbox" class="' + bodyClasses + '">' +
-								body +
-							'</body>' +
-						'</html>'
-					);
-					iframeDoc.close();
-
-					resize = function() {
-						// Make sure the iframe still exists.
-						iframe.contentWindow && $( iframe ).height( $( iframeDoc.body ).height() );
-					};
-
-					if ( MutationObserver ) {
-						new MutationObserver( _.debounce( function() {
-							resize();
-						}, 100 ) )
-						.observe( iframeDoc.body, {
-							attributes: true,
-							childList: true,
-							subtree: true
-						} );
-					} else {
-						for ( i = 1; i < 6; i++ ) {
-							setTimeout( resize, i * 700 );
-						}
-					}
-
-					editor.on( 'wp-body-class-change', function() {
-						iframeDoc.body.className = editor.getBody().className;
-					});
-				}, 50 );
-			});
-
-		},
-
 		fetch : function() {
 
 			var self = this;
@@ -535,9 +419,15 @@ var shortcodeViewConstructor = {
 					shortcode: this.shortcode.formatShortcode(),
 					nonce: shortcodeUIData.nonces.preview,
 				}).done( function( response ) {
-					self.setHtml( response );
+					if ( response.indexOf( '<script' ) !== -1 ) {
+						self.setIframes( self.getEditorStyles(), response );
+					} else {
+						self.parsed = true;
+						self.render( true );
+					}
 				}).fail( function() {
-					self.setHtml( '<span class="shortcake-error">' + shortcodeUIData.strings.mce_view_error + '</span>' );
+					self.parsed = '<span class="shortcake-error">' + shortcodeUIData.strings.mce_view_error + '</span>';
+					self.render( true );
 				} );
 
 			}
@@ -546,23 +436,57 @@ var shortcodeViewConstructor = {
 
 		/**
 		 * Render the shortcode
-		 * 
+		 *
 		 * To ensure consistent rendering - this makes an ajax request to the
 		 * admin and displays.
-		 * 
+		 *
 		 * @return string html
 		 */
 		getHtml : function() {
+
+			if ( ! this.parsed ) {
+				this.fetch();
+			}
+
 			return this.parsed;
-		}
+		},
+
+		/**
+		 * Returns an array of <link> tags for stylesheets applied to the TinyMCE editor.
+		 *
+		 * @method getEditorStyles
+		 * @returns {Array}
+		 */
+		getEditorStyles: function() {
+
+			var styles = '';
+
+			this.getNodes( function ( editor, node, content ) {
+				var dom = editor.dom,
+					bodyClasses = editor.getBody().className || '',
+					iframe, iframeDoc, i, resize;
+
+				tinymce.each( dom.$( 'link[rel="stylesheet"]', editor.getDoc().head ), function( link ) {
+					if ( link.href && link.href.indexOf( 'skins/lightgray/content.min.css' ) === -1 &&
+						link.href.indexOf( 'skins/wordpress/wp-content.css' ) === -1 ) {
+
+						styles += dom.getOuterHTML( link ) + '\n';
+					}
+
+				});
+
+			} );
+
+			return styles;
+		},
 
 	},
 
 	/**
 	 * Edit shortcode.
-	 * 
+	 *
 	 * Parses the shortcode and creates shortcode mode.
-	 * 
+	 *
 	 * @todo - I think there must be a cleaner way to get the shortcode & args
 	 *       here that doesn't use regex.
 	 */

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -373,7 +373,6 @@ var shortcodeViewConstructor = {
 
 		initialize: function( options ) {
 			this.shortcode = this.getShortcode( options );
-			this.fetch();
 		},
 
 		getShortcode: function( options ) {

--- a/js/utils/shortcode-view-constructor.js
+++ b/js/utils/shortcode-view-constructor.js
@@ -6,6 +6,8 @@ var shortcodeViewConstructor = {
 
 	View: {
 
+		overlay: true,
+
 		initialize: function( options ) {
 			this.shortcode = this.getShortcode( options );
 			this.fetch();
@@ -43,124 +45,6 @@ var shortcodeViewConstructor = {
 
 		},
 
-		/**
-		 * Set the HTML. Modeled after wp.mce.View.setIframes
-		 *
-		 * If it includes a script tag, needs to be wrapped in an iframe
-		 */
-		setHtml: function( body ) {
-
-			var MutationObserver = window.MutationObserver || window.WebKitMutationObserver || window.MozMutationObserver;
-
-			if ( body.indexOf( '<script' ) === -1 ) {
-				this.parsed = body;
-				this.render( true );
-				return;
-			}
-
-			this.getNodes( function ( editor, node, content ) {
-				var dom = editor.dom,
-				styles = '',
-				bodyClasses = editor.getBody().className || '',
-				iframe, iframeDoc, i, resize;
-
-				content.innerHTML = '';
-				head = '';
-
-				$(node).addClass('wp-mce-view-show-toolbar');
-
-				if ( ! wp.mce.views.sandboxStyles ) {
-					tinymce.each( dom.$( 'link[rel="stylesheet"]', editor.getDoc().head ), function( link ) {
-						if ( link.href && link.href.indexOf( 'skins/lightgray/content.min.css' ) === -1 &&
-							link.href.indexOf( 'skins/wordpress/wp-content.css' ) === -1 ) {
-
-							styles += dom.getOuterHTML( link ) + '\n';
-						}
-					});
-
-					wp.mce.views.sandboxStyles = styles;
-				} else {
-					styles = wp.mce.views.sandboxStyles;
-				}
-
-				// Seems Firefox needs a bit of time to insert/set the view nodes, or the iframe will fail
-				// especially when switching Text => Visual.
-				setTimeout( function() {
-					iframe = dom.add( content, 'iframe', {
-						src: tinymce.Env.ie ? 'javascript:""' : '',
-						frameBorder: '0',
-						allowTransparency: 'true',
-						scrolling: 'no',
-						'class': 'wpview-sandbox',
-						style: {
-							width: '100%',
-							display: 'block'
-						}
-					} );
-
-					iframeDoc = iframe.contentWindow.document;
-
-					iframeDoc.open();
-					iframeDoc.write(
-						'<!DOCTYPE html>' +
-						'<html>' +
-							'<head>' +
-								'<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />' +
-								head +
-								styles +
-								'<style>' +
-									'html {' +
-										'background: transparent;' +
-										'padding: 0;' +
-										'margin: 0;' +
-									'}' +
-									'body#wpview-iframe-sandbox {' +
-										'background: transparent;' +
-										'padding: 1px 0 !important;' +
-										'margin: -1px 0 0 !important;' +
-									'}' +
-									'body#wpview-iframe-sandbox:before,' +
-									'body#wpview-iframe-sandbox:after {' +
-										'display: none;' +
-										'content: "";' +
-									'}' +
-								'</style>' +
-							'</head>' +
-							'<body id="wpview-iframe-sandbox" class="' + bodyClasses + '">' +
-								body +
-							'</body>' +
-						'</html>'
-					);
-					iframeDoc.close();
-
-					resize = function() {
-						// Make sure the iframe still exists.
-						iframe.contentWindow && $( iframe ).height( $( iframeDoc.body ).height() );
-					};
-
-					if ( MutationObserver ) {
-						new MutationObserver( _.debounce( function() {
-							resize();
-						}, 100 ) )
-						.observe( iframeDoc.body, {
-							attributes: true,
-							childList: true,
-							subtree: true
-						} );
-					} else {
-						for ( i = 1; i < 6; i++ ) {
-							setTimeout( resize, i * 700 );
-						}
-					}
-
-					editor.on( 'wp-body-class-change', function() {
-						iframeDoc.body.className = editor.getBody().className;
-					});
-				}, 50 );
-			});
-
-		},
-
 		fetch : function() {
 
 			var self = this;
@@ -172,9 +56,15 @@ var shortcodeViewConstructor = {
 					shortcode: this.shortcode.formatShortcode(),
 					nonce: shortcodeUIData.nonces.preview,
 				}).done( function( response ) {
-					self.setHtml( response );
+					if ( response.indexOf( '<script' ) !== -1 ) {
+						self.setIframes( self.getEditorStyles(), response );
+					} else {
+						self.parsed = true;
+						self.render( true );
+					}
 				}).fail( function() {
-					self.setHtml( '<span class="shortcake-error">' + shortcodeUIData.strings.mce_view_error + '</span>' );
+					self.parsed = '<span class="shortcake-error">' + shortcodeUIData.strings.mce_view_error + '</span>';
+					self.render( true );
 				} );
 
 			}
@@ -183,23 +73,57 @@ var shortcodeViewConstructor = {
 
 		/**
 		 * Render the shortcode
-		 * 
+		 *
 		 * To ensure consistent rendering - this makes an ajax request to the
 		 * admin and displays.
-		 * 
+		 *
 		 * @return string html
 		 */
 		getHtml : function() {
+
+			if ( ! this.parsed ) {
+				this.fetch();
+			}
+
 			return this.parsed;
-		}
+		},
+
+		/**
+		 * Returns an array of <link> tags for stylesheets applied to the TinyMCE editor.
+		 *
+		 * @method getEditorStyles
+		 * @returns {Array}
+		 */
+		getEditorStyles: function() {
+
+			var styles = '';
+
+			this.getNodes( function ( editor, node, content ) {
+				var dom = editor.dom,
+					bodyClasses = editor.getBody().className || '',
+					iframe, iframeDoc, i, resize;
+
+				tinymce.each( dom.$( 'link[rel="stylesheet"]', editor.getDoc().head ), function( link ) {
+					if ( link.href && link.href.indexOf( 'skins/lightgray/content.min.css' ) === -1 &&
+						link.href.indexOf( 'skins/wordpress/wp-content.css' ) === -1 ) {
+
+						styles += dom.getOuterHTML( link ) + '\n';
+					}
+
+				});
+
+			} );
+
+			return styles;
+		},
 
 	},
 
 	/**
 	 * Edit shortcode.
-	 * 
+	 *
 	 * Parses the shortcode and creates shortcode mode.
-	 * 
+	 *
 	 * @todo - I think there must be a cleaner way to get the shortcode & args
 	 *       here that doesn't use regex.
 	 */

--- a/js/utils/shortcode-view-constructor.js
+++ b/js/utils/shortcode-view-constructor.js
@@ -10,7 +10,6 @@ var shortcodeViewConstructor = {
 
 		initialize: function( options ) {
 			this.shortcode = this.getShortcode( options );
-			this.fetch();
 		},
 
 		getShortcode: function( options ) {


### PR DESCRIPTION
Fixes #202 
- Setting `overlay: true` on the view is a workaround for making the iframes focusable/selectable.
- If we make use of  `setIframes` instead of trying to do it ourselves, it fixes the duplicate preview bug.
- We still need a workaround for loading styles -  `getEditorStyles` although I've opened a trac ticket that will remove this requirement*. 

*I think its still relevant following the 4.2 improvements - see #181
