### PR TITLE
Updated JS to respect jQuery.noConflict() mode in WP

### DIFF
--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -101,7 +101,7 @@ describe( "Shortcode Model", function() {
 
 	it( 'Format shortcode.', function() {
 
-		var _shortcode = $.extend( true, {}, shortcode );
+		var _shortcode = jQuery.extend( true, {}, shortcode );
 
 		// Test with attribute and with content.
 		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode attr="test value"]test content[/test_shortcode]' );
@@ -119,7 +119,7 @@ describe( "Shortcode Model", function() {
 var Shortcode = require('./../../../js/models/shortcode.js');
 var MceViewConstructor = require('./../../../js/utils/shortcode-view-constructor.js');
 var sui = require('./../../../js/utils/sui.js');
-var $ = (typeof window !== "undefined" ? window.jQuery : typeof global !== "undefined" ? global.jQuery : null);
+var jQuery = (typeof window !== "undefined" ? window.jQuery : typeof global !== "undefined" ? global.jQuery : null);
 var wp = (typeof window !== "undefined" ? window.wp : typeof global !== "undefined" ? global.wp : null);
 
 describe( "MCE View Constructor", function() {
@@ -154,7 +154,7 @@ describe( "MCE View Constructor", function() {
 
 	it ( 'test get shortcode model', function() {
 
-		var constructor = $.extend( true, {}, MceViewConstructor );
+		var constructor = jQuery.extend( true, {}, MceViewConstructor );
 
 		constructor.shortcode = {
 			tag: "test_shortcode",
@@ -175,7 +175,7 @@ describe( "MCE View Constructor", function() {
 
 	it ( 'test getContent.', function() {
 
-		var constructor = $.extend( true, {}, MceViewConstructor );
+		var constructor = jQuery.extend( true, {}, MceViewConstructor );
 
 		spyOn( constructor, 'fetch' );
 
@@ -201,12 +201,12 @@ describe( "MCE View Constructor", function() {
 			jasmine.Ajax.uninstall();
 		});
 
-		var constructor = $.extend( true, {
+		var constructor = jQuery.extend( true, {
 			render: function( force ) {},
 		}, MceViewConstructor );
 
 		// Mock shortcode model data.
-		constructor.shortcodeModel = $.extend( true, {}, sui.shortcodes.first() );
+		constructor.shortcodeModel = jQuery.extend( true, {}, sui.shortcodes.first() );
 
 		it( 'Fetches data success', function(){
 
@@ -466,7 +466,7 @@ module.exports = Shortcode;
 (function (global){
 sui = require('./sui.js');
 wp = (typeof window !== "undefined" ? window.wp : typeof global !== "undefined" ? global.wp : null);
-$ = (typeof window !== "undefined" ? window.jQuery : typeof global !== "undefined" ? global.jQuery : null);
+jQuery = (typeof window !== "undefined" ? window.jQuery : typeof global !== "undefined" ? global.jQuery : null);
 
 /**
  * Generic shortcode mce view constructor.
@@ -542,7 +542,7 @@ var shortcodeViewConstructor = {
 			this.fetching = true;
 
 			wp.ajax.post( 'do_shortcode', {
-				post_id: $( '#post_ID' ).val(),
+				post_id: jQuery( '#post_ID' ).val(),
 				shortcode: this.shortcodeModel.formatShortcode(),
 				nonce: shortcodeUIData.nonces.preview,
 			}).done( function( response ) {
@@ -569,7 +569,7 @@ var shortcodeViewConstructor = {
 
 		// Backwards compatability for WP pre-4.2
 		if ( 'object' === typeof( shortcodeString ) ) {
-			shortcodeString = decodeURIComponent( $(shortcodeString).attr('data-wpview-text') );
+			shortcodeString = decodeURIComponent( jQuery(shortcodeString).attr('data-wpview-text') );
 		}
 
 		currentShortcode = this.parseShortcodeString( shortcodeString );
@@ -698,7 +698,7 @@ var shortcodeViewConstructor = {
 			if ( ! this.parsed ) {
 
 				wp.ajax.post( 'do_shortcode', {
-					post_id: $( '#post_ID' ).val(),
+					post_id: jQuery( '#post_ID' ).val(),
 					shortcode: this.shortcode.formatShortcode(),
 					nonce: shortcodeUIData.nonces.preview,
 				}).done( function( response ) {

--- a/js-tests/src/shortcodeModelSpec.js
+++ b/js-tests/src/shortcodeModelSpec.js
@@ -54,7 +54,7 @@ describe( "Shortcode Model", function() {
 
 	it( 'Format shortcode.', function() {
 
-		var _shortcode = $.extend( true, {}, shortcode );
+		var _shortcode = jQuery.extend( true, {}, shortcode );
 
 		// Test with attribute and with content.
 		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode attr="test value"]test content[/test_shortcode]' );

--- a/js-tests/src/utils/mceViewConstructorSpec.js
+++ b/js-tests/src/utils/mceViewConstructorSpec.js
@@ -1,7 +1,7 @@
 var Shortcode = require('sui-models/shortcode');
 var MceViewConstructor = require('sui-utils/shortcode-view-constructor');
 var sui = require('sui-utils/sui');
-var $ = require('jquery');
+var jQuery = require('jquery');
 var wp = require('wp');
 
 describe( "MCE View Constructor", function() {
@@ -36,7 +36,7 @@ describe( "MCE View Constructor", function() {
 
 	it ( 'test get shortcode model', function() {
 
-		var constructor = $.extend( true, {}, MceViewConstructor );
+		var constructor = jQuery.extend( true, {}, MceViewConstructor );
 
 		constructor.shortcode = {
 			tag: "test_shortcode",
@@ -57,7 +57,7 @@ describe( "MCE View Constructor", function() {
 
 	it ( 'test getContent.', function() {
 
-		var constructor = $.extend( true, {}, MceViewConstructor );
+		var constructor = jQuery.extend( true, {}, MceViewConstructor );
 
 		spyOn( constructor, 'fetch' );
 
@@ -83,12 +83,12 @@ describe( "MCE View Constructor", function() {
 			jasmine.Ajax.uninstall();
 		});
 
-		var constructor = $.extend( true, {
+		var constructor = jQuery.extend( true, {
 			render: function( force ) {},
 		}, MceViewConstructor );
 
 		// Mock shortcode model data.
-		constructor.shortcodeModel = $.extend( true, {}, sui.shortcodes.first() );
+		constructor.shortcodeModel = jQuery.extend( true, {}, sui.shortcodes.first() );
 
 		it( 'Fetches data success', function(){
 

--- a/js-tests/vendor/wp-util.js
+++ b/js-tests/vendor/wp-util.js
@@ -30,7 +30,7 @@ window.wp = window.wp || {};
 			};
 
 		return function ( data ) {
-			compiled = compiled || _.template( $( '#tmpl-' + id ).html(), null, options );
+			compiled = compiled || _.template( jQuery( '#tmpl-' + id ).html(), null, options );
 			return compiled( data );
 		};
 	});

--- a/js/build/field-attachment.js
+++ b/js/build/field-attachment.js
@@ -36,7 +36,7 @@ module.exports = Shortcodes;
 (function (global){
 var sui = require('./utils/sui.js'),
     editAttributeField = require('./views/edit-attribute-field.js'),
-    $ = (typeof window !== "undefined" ? window.jQuery : typeof global !== "undefined" ? global.jQuery : null);
+    jQuery = (typeof window !== "undefined" ? window.jQuery : typeof global !== "undefined" ? global.jQuery : null);
 
 // Cache attachment IDs for quicker loading.
 var iDCache = {};
@@ -108,23 +108,23 @@ sui.views.editAttributeFieldAttachment = editAttributeField.extend( {
 		 */
 		var renderPreview = function( attachment ) {
 
-			var $thumbnail = $('<div class="thumbnail"></div>');
+			var $thumbnail = jQuery('<div class="thumbnail"></div>');
 
 			if ( 'image' !== attachment.type ) {
 
-				$( '<img/>', {
+				jQuery( '<img/>', {
 					src: attachment.icon,
 					alt: attachment.title,
 				} ).appendTo( $thumbnail );
 
-				$( '<div/>', {
+				jQuery( '<div/>', {
 					class: 'filename',
 					html:  '<div>' + attachment.title + '</div>',
 				} ).appendTo( $thumbnail );
 
 			} else {
 
-				$( '<img/>', {
+				jQuery( '<img/>', {
 					src:    attachment.sizes.thumbnail.url,
 					width:  attachment.sizes.thumbnail.width,
 					height: attachment.sizes.thumbnail.height,
@@ -362,9 +362,9 @@ var editAttributeField = Backbone.View.extend( {
 	updateValue: function( e ) {
 
 		if ( this.model.get( 'attr' ) ) {
-			var $el = $( this.el ).find( '[name=' + this.model.get( 'attr' ) + ']' );
+			var $el = jQuery( this.el ).find( '[name=' + this.model.get( 'attr' ) + ']' );
 		} else {
-			var $el = $( this.el ).find( '[name="inner_content"]' );
+			var $el = jQuery( this.el ).find( '[name="inner_content"]' );
 		}
 
 		if ( 'radio' === this.model.attributes.type ) {

--- a/js/build/field-color.js
+++ b/js/build/field-color.js
@@ -36,7 +36,7 @@ module.exports = Shortcodes;
 (function (global){
 var sui = require('./utils/sui.js'),
     editAttributeField = require('./views/edit-attribute-field.js'),
-    $ = (typeof window !== "undefined" ? window.jQuery : typeof global !== "undefined" ? global.jQuery : null);
+    jQuery = (typeof window !== "undefined" ? window.jQuery : typeof global !== "undefined" ? global.jQuery : null);
 
 sui.views.editAttributeFieldColor = editAttributeField.extend( {
 
@@ -233,9 +233,9 @@ var editAttributeField = Backbone.View.extend( {
 	updateValue: function( e ) {
 
 		if ( this.model.get( 'attr' ) ) {
-			var $el = $( this.el ).find( '[name=' + this.model.get( 'attr' ) + ']' );
+			var $el = jQuery( this.el ).find( '[name=' + this.model.get( 'attr' ) + ']' );
 		} else {
-			var $el = $( this.el ).find( '[name="inner_content"]' );
+			var $el = jQuery( this.el ).find( '[name="inner_content"]' );
 		}
 
 		if ( 'radio' === this.model.attributes.type ) {

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -226,9 +226,9 @@ var sui = require('./utils/sui.js'),
 	shortcodeViewConstructor = require('./utils/shortcode-view-constructor.js'),
 	mediaFrame = require('./views/media-frame.js'),
 	wp = (typeof window !== "undefined" ? window.wp : typeof global !== "undefined" ? global.wp : null),
-	$ = (typeof window !== "undefined" ? window.jQuery : typeof global !== "undefined" ? global.jQuery : null);
+	jQuery = (typeof window !== "undefined" ? window.jQuery : typeof global !== "undefined" ? global.jQuery : null);
 
-$(document).ready(function(){
+jQuery(document).ready(function(){
 
 	// Create collection of shortcode models from data.
 	sui.shortcodes.add( shortcodeUIData.shortcodes );
@@ -242,7 +242,7 @@ $(document).ready(function(){
 				shortcode.get('shortcode_tag'),
 				// Must extend for 4.1.
 				// This is handled by wp.mce.views.register in 4.2.
-				$.extend( true, {}, shortcodeViewConstructor )
+				jQuery.extend( true, {}, shortcodeViewConstructor )
 			);
 		}
 	} );
@@ -254,7 +254,7 @@ $(document).ready(function(){
 (function (global){
 sui = require('./sui.js');
 wp = (typeof window !== "undefined" ? window.wp : typeof global !== "undefined" ? global.wp : null);
-$ = (typeof window !== "undefined" ? window.jQuery : typeof global !== "undefined" ? global.jQuery : null);
+jQuery = (typeof window !== "undefined" ? window.jQuery : typeof global !== "undefined" ? global.jQuery : null);
 
 /**
  * Generic shortcode mce view constructor.
@@ -330,7 +330,7 @@ var shortcodeViewConstructor = {
 			this.fetching = true;
 
 			wp.ajax.post( 'do_shortcode', {
-				post_id: $( '#post_ID' ).val(),
+				post_id: jQuery( '#post_ID' ).val(),
 				shortcode: this.shortcodeModel.formatShortcode(),
 				nonce: shortcodeUIData.nonces.preview,
 			}).done( function( response ) {
@@ -357,7 +357,7 @@ var shortcodeViewConstructor = {
 
 		// Backwards compatability for WP pre-4.2
 		if ( 'object' === typeof( shortcodeString ) ) {
-			shortcodeString = decodeURIComponent( $(shortcodeString).attr('data-wpview-text') );
+			shortcodeString = decodeURIComponent( jQuery(shortcodeString).attr('data-wpview-text') );
 		}
 
 		currentShortcode = this.parseShortcodeString( shortcodeString );
@@ -486,7 +486,7 @@ var shortcodeViewConstructor = {
 			if ( ! this.parsed ) {
 
 				wp.ajax.post( 'do_shortcode', {
-					post_id: $( '#post_ID' ).val(),
+					post_id: jQuery( '#post_ID' ).val(),
 					shortcode: this.shortcode.formatShortcode(),
 					nonce: shortcodeUIData.nonces.preview,
 				}).done( function( response ) {
@@ -604,9 +604,9 @@ var editAttributeField = Backbone.View.extend( {
 	updateValue: function( e ) {
 
 		if ( this.model.get( 'attr' ) ) {
-			var $el = $( this.el ).find( '[name=' + this.model.get( 'attr' ) + ']' );
+			var $el = jQuery( this.el ).find( '[name=' + this.model.get( 'attr' ) + ']' );
 		} else {
-			var $el = $( this.el ).find( '[name="inner_content"]' );
+			var $el = jQuery( this.el ).find( '[name="inner_content"]' );
 		}
 
 		if ( 'radio' === this.model.attributes.type ) {
@@ -1018,7 +1018,7 @@ var ShortcodePreview = Backbone.View.extend({
 
 		_.defaults( params || {}, { 'head': '', 'body': '', 'body_classes': 'shortcake shortcake-preview' });
 
-		$iframe = $( '<iframe/>', {
+		$iframe = jQuery( '<iframe/>', {
 			src: tinymce.Env.ie ? 'javascript:""' : '',
 			frameBorder: '0',
 			allowTransparency: 'true',
@@ -1033,10 +1033,10 @@ var ShortcodePreview = Backbone.View.extend({
 		 */
 		$iframe.load( function() {
 
-			self.autoresizeIframe( $(this) );
+			self.autoresizeIframe( jQuery(this) );
 
-			var head = $(this).contents().find('head'),
-			    body = $(this).contents().find('body');
+			var head = jQuery(this).contents().find('head'),
+			    body = jQuery(this).contents().find('body');
 
 			head.html( params.head );
 			body.html( params.body );
@@ -1099,7 +1099,7 @@ var ShortcodePreview = Backbone.View.extend({
 	fetchShortcode: function( callback ) {
 
 		wp.ajax.post( 'do_shortcode', {
-			post_id: $( '#post_ID' ).val(),
+			post_id: jQuery( '#post_ID' ).val(),
 			shortcode: this.model.formatShortcode(),
 			nonce: shortcodeUIData.nonces.preview,
 		}).done( function( response ) {
@@ -1127,7 +1127,7 @@ var ShortcodePreview = Backbone.View.extend({
 		});
 
 		styles = _.map( _.keys( styles ), function( href ) {
-			return $( '<link rel="stylesheet" type="text/css">' ).attr( 'href', href )[0].outerHTML;
+			return jQuery( '<link rel="stylesheet" type="text/css">' ).attr( 'href', href )[0].outerHTML;
 		});
 
 		return styles;
@@ -1147,7 +1147,7 @@ var Backbone = (typeof window !== "undefined" ? window.Backbone : typeof global 
 	Toolbar = require('./media-toolbar.js'),
 	SearchShortcode = require('./search-shortcode.js'),
 	sui = require('./../utils/sui.js');
-	$ = (typeof window !== "undefined" ? window.jQuery : typeof global !== "undefined" ? global.jQuery : null);
+	jQuery = (typeof window !== "undefined" ? window.jQuery : typeof global !== "undefined" ? global.jQuery : null);
 
 var Shortcode_UI = Backbone.View.extend({
 
@@ -1247,7 +1247,7 @@ var Shortcode_UI = Backbone.View.extend({
 
 	select: function(e) {
 		this.controller.props.set( 'action', 'insert' );
-		var target    = $(e.currentTarget).closest( '.shortcode-list-item' );
+		var target    = jQuery(e.currentTarget).closest( '.shortcode-list-item' );
 		var shortcode = sui.shortcodes.findWhere( { shortcode_tag: target.attr( 'data-shortcode' ) } );
 
 		if ( ! shortcode ) {
@@ -1341,7 +1341,7 @@ var TabbedView = Backbone.View.extend({
 		event.stopPropagation();
 		event.preventDefault();
 
-		var target = $(event.currentTarget).attr('data-target');
+		var target = jQuery(event.currentTarget).attr('data-target');
 
 		this.select(target);
 	},

--- a/js/field-attachment.js
+++ b/js/field-attachment.js
@@ -1,6 +1,6 @@
 var sui = require('sui-utils/sui'),
     editAttributeField = require( 'sui-views/edit-attribute-field' ),
-    $ = require('jquery');
+    jQuery = require('jquery');
 
 // Cache attachment IDs for quicker loading.
 var iDCache = {};
@@ -72,23 +72,23 @@ sui.views.editAttributeFieldAttachment = editAttributeField.extend( {
 		 */
 		var renderPreview = function( attachment ) {
 
-			var $thumbnail = $('<div class="thumbnail"></div>');
+			var $thumbnail = jQuery('<div class="thumbnail"></div>');
 
 			if ( 'image' !== attachment.type ) {
 
-				$( '<img/>', {
+				jQuery( '<img/>', {
 					src: attachment.icon,
 					alt: attachment.title,
 				} ).appendTo( $thumbnail );
 
-				$( '<div/>', {
+				jQuery( '<div/>', {
 					class: 'filename',
 					html:  '<div>' + attachment.title + '</div>',
 				} ).appendTo( $thumbnail );
 
 			} else {
 
-				$( '<img/>', {
+				jQuery( '<img/>', {
 					src:    attachment.sizes.thumbnail.url,
 					width:  attachment.sizes.thumbnail.width,
 					height: attachment.sizes.thumbnail.height,

--- a/js/field-color.js
+++ b/js/field-color.js
@@ -1,6 +1,6 @@
 var sui = require('sui-utils/sui'),
     editAttributeField = require( 'sui-views/edit-attribute-field' ),
-    $ = require('jquery');
+    jQuery = require('jquery');
 
 sui.views.editAttributeFieldColor = editAttributeField.extend( {
 

--- a/js/shortcode-ui.js
+++ b/js/shortcode-ui.js
@@ -3,9 +3,9 @@ var sui = require('sui-utils/sui'),
 	shortcodeViewConstructor = require('sui-utils/shortcode-view-constructor'),
 	mediaFrame = require('sui-views/media-frame'),
 	wp = require('wp'),
-	$ = require('jquery');
+	jQuery = require('jquery');
 
-$(document).ready(function(){
+jQuery(document).ready(function(){
 
 	// Create collection of shortcode models from data.
 	sui.shortcodes.add( shortcodeUIData.shortcodes );
@@ -19,7 +19,7 @@ $(document).ready(function(){
 				shortcode.get('shortcode_tag'),
 				// Must extend for 4.1.
 				// This is handled by wp.mce.views.register in 4.2.
-				$.extend( true, {}, shortcodeViewConstructor )
+				jQuery.extend( true, {}, shortcodeViewConstructor )
 			);
 		}
 	} );

--- a/js/utils/shortcode-view-constructor.js
+++ b/js/utils/shortcode-view-constructor.js
@@ -1,6 +1,6 @@
 sui = require('sui-utils/sui');
 wp = require('wp');
-$ = require('jquery');
+jQuery = require('jquery');
 
 /**
  * Generic shortcode mce view constructor.
@@ -76,7 +76,7 @@ var shortcodeViewConstructor = {
 			this.fetching = true;
 
 			wp.ajax.post( 'do_shortcode', {
-				post_id: $( '#post_ID' ).val(),
+				post_id: jQuery( '#post_ID' ).val(),
 				shortcode: this.shortcodeModel.formatShortcode(),
 				nonce: shortcodeUIData.nonces.preview,
 			}).done( function( response ) {
@@ -103,7 +103,7 @@ var shortcodeViewConstructor = {
 
 		// Backwards compatability for WP pre-4.2
 		if ( 'object' === typeof( shortcodeString ) ) {
-			shortcodeString = decodeURIComponent( $(shortcodeString).attr('data-wpview-text') );
+			shortcodeString = decodeURIComponent( jQuery(shortcodeString).attr('data-wpview-text') );
 		}
 
 		currentShortcode = this.parseShortcodeString( shortcodeString );
@@ -232,7 +232,7 @@ var shortcodeViewConstructor = {
 			if ( ! this.parsed ) {
 
 				wp.ajax.post( 'do_shortcode', {
-					post_id: $( '#post_ID' ).val(),
+					post_id: jQuery( '#post_ID' ).val(),
 					shortcode: this.shortcode.formatShortcode(),
 					nonce: shortcodeUIData.nonces.preview,
 				}).done( function( response ) {

--- a/js/views/edit-attribute-field.js
+++ b/js/views/edit-attribute-field.js
@@ -31,9 +31,9 @@ var editAttributeField = Backbone.View.extend( {
 	updateValue: function( e ) {
 
 		if ( this.model.get( 'attr' ) ) {
-			var $el = $( this.el ).find( '[name=' + this.model.get( 'attr' ) + ']' );
+			var $el = jQuery( this.el ).find( '[name=' + this.model.get( 'attr' ) + ']' );
 		} else {
-			var $el = $( this.el ).find( '[name="inner_content"]' );
+			var $el = jQuery( this.el ).find( '[name="inner_content"]' );
 		}
 
 		if ( 'radio' === this.model.attributes.type ) {

--- a/js/views/shortcode-preview.js
+++ b/js/views/shortcode-preview.js
@@ -61,7 +61,7 @@ var ShortcodePreview = Backbone.View.extend({
 
 		_.defaults( params || {}, { 'head': '', 'body': '', 'body_classes': 'shortcake shortcake-preview' });
 
-		$iframe = $( '<iframe/>', {
+		$iframe = jQuery( '<iframe/>', {
 			src: tinymce.Env.ie ? 'javascript:""' : '',
 			frameBorder: '0',
 			allowTransparency: 'true',
@@ -76,10 +76,10 @@ var ShortcodePreview = Backbone.View.extend({
 		 */
 		$iframe.load( function() {
 
-			self.autoresizeIframe( $(this) );
+			self.autoresizeIframe( jQuery(this) );
 
-			var head = $(this).contents().find('head'),
-			    body = $(this).contents().find('body');
+			var head = jQuery(this).contents().find('head'),
+			    body = jQuery(this).contents().find('body');
 
 			head.html( params.head );
 			body.html( params.body );
@@ -142,7 +142,7 @@ var ShortcodePreview = Backbone.View.extend({
 	fetchShortcode: function( callback ) {
 
 		wp.ajax.post( 'do_shortcode', {
-			post_id: $( '#post_ID' ).val(),
+			post_id: jQuery( '#post_ID' ).val(),
 			shortcode: this.model.formatShortcode(),
 			nonce: shortcodeUIData.nonces.preview,
 		}).done( function( response ) {
@@ -170,7 +170,7 @@ var ShortcodePreview = Backbone.View.extend({
 		});
 
 		styles = _.map( _.keys( styles ), function( href ) {
-			return $( '<link rel="stylesheet" type="text/css">' ).attr( 'href', href )[0].outerHTML;
+			return jQuery( '<link rel="stylesheet" type="text/css">' ).attr( 'href', href )[0].outerHTML;
 		});
 
 		return styles;

--- a/js/views/shortcode-ui.js
+++ b/js/views/shortcode-ui.js
@@ -6,7 +6,7 @@ var Backbone = require('backbone'),
 	Toolbar = require('sui-views/media-toolbar'),
 	SearchShortcode = require('sui-views/search-shortcode'),
 	sui = require('sui-utils/sui');
-	$ = require('jquery');
+	jQuery = require('jquery');
 
 var Shortcode_UI = Backbone.View.extend({
 
@@ -106,7 +106,7 @@ var Shortcode_UI = Backbone.View.extend({
 
 	select: function(e) {
 		this.controller.props.set( 'action', 'insert' );
-		var target    = $(e.currentTarget).closest( '.shortcode-list-item' );
+		var target    = jQuery(e.currentTarget).closest( '.shortcode-list-item' );
 		var shortcode = sui.shortcodes.findWhere( { shortcode_tag: target.attr( 'data-shortcode' ) } );
 
 		if ( ! shortcode ) {

--- a/js/views/tabbed-view.js
+++ b/js/views/tabbed-view.js
@@ -72,7 +72,7 @@ var TabbedView = Backbone.View.extend({
 		event.stopPropagation();
 		event.preventDefault();
 
-		var target = $(event.currentTarget).attr('data-target');
+		var target = jQuery(event.currentTarget).attr('data-target');
 
 		this.select(target);
 	},


### PR DESCRIPTION
Currently the plugin is forcing the `jQuery` variable to be set back to `$`. This can have some odd interactions with other plugins in some cases. I discovered this when another plugin in use (multilingual-press-pro) calls `jQuery.noConflict()` again for some reason. That reset the `$` var causing shortcake to error.
