### PR TITLE
Attributes without quotes and extra template options

### DIFF
--- a/inc/templates/edit-form.tpl.php
+++ b/inc/templates/edit-form.tpl.php
@@ -17,8 +17,8 @@
 
 <script type="text/html" id="tmpl-shortcode-ui-field-text">
 	<div class="field-block">
-		<label for="{{ data.attr }}">{{ data.label }}</label>
-		<input type="text" name="{{ data.attr }}" id="{{ data.attr }}" value="{{ data.value }}" placeholder="{{ data.placeholder }}"/>
+		<label for="{{ data.attr }}">{{ data.label }}<# if ( data.required == true ) { #> *<# } #></label>
+		<input type="text" name="{{ data.attr }}" id="{{ data.attr }}" value="{{ data.value }}"  size="{{ data.size }}" placeholder="{{ data.placeholder }}"/>
 		<# if ( typeof data.description == 'string' ) { #>
 			<p class="description">{{ data.description }}</p>
 		<# } #>
@@ -27,8 +27,8 @@
 
 <script type="text/html" id="tmpl-shortcode-ui-field-url">
 	<div class="field-block">
-		<label for="{{ data.attr }}">{{ data.label }}</label>
-		<input type="url" name="{{ data.attr }}" id="{{ data.attr }}" value="{{ data.value }}" class="code" placeholder="{{ data.placeholder }}"/>
+		<label for="{{ data.attr }}">{{ data.label }}<# if ( data.required == true ) { #> *<# } #></label>
+		<input type="url" name="{{ data.attr }}" id="{{ data.attr }}" value="{{ data.value }}" size="{{ data.size }}" class="code" placeholder="{{ data.placeholder }}"/>
 		<# if ( typeof data.description == 'string' ) { #>
 			<p class="description">{{ data.description }}</p>
 		<# } #>
@@ -37,8 +37,8 @@
 
 <script type="text/html" id="tmpl-shortcode-ui-field-textarea">
 	<div class="field-block">
-		<label for="{{ data.attr }}">{{ data.label }}</label>
-		<textarea name="{{ data.attr }}" id="{{ data.attr }}" placeholder="{{ data.placeholder }}">{{ data.value }}</textarea>
+		<label for="{{ data.attr }}">{{ data.label }<# if ( data.required == true ) { #> *<# } #>}</label>
+		<textarea name="{{ data.attr }}" id="{{ data.attr }}" cols="{{ data.cols }}" rows="{{ data.rows }}" placeholder="{{ data.placeholder }}">{{ data.value }}</textarea>
 		<# if ( typeof data.description == 'string' ) { #>
 			<p class="description">{{ data.description }}</p>
 		<# } #>
@@ -47,7 +47,7 @@
 
 <script type="text/html" id="tmpl-shortcode-ui-field-select">
 	<div class="field-block">
-		<label for="{{ data.attr }}">{{ data.label }}</label>
+		<label for="{{ data.attr }}">{{ data.label }}<# if ( data.required == true ) { #> *<# } #></label>
 		<select name="{{ data.attr }}" id="{{ data.attr }}">
 			<# _.each( data.options, function( label, value ) { #>
 				<option value="{{ value }}" <# if ( value == data.value ){ print('selected'); } #>>{{ label }}</option>
@@ -61,7 +61,7 @@
 
 <script type="text/html" id="tmpl-shortcode-ui-field-radio">
 	<div class="field-block">
-		<label for="{{ data.attr }}">{{ data.label }}</label>
+		<label for="{{ data.attr }}">{{ data.label }}<# if ( data.required == true ) { #> *<# } #></label>
 		<# _.each( data.options, function( label, value ) { #>
 			<input type="radio" name="{{ data.attr }}" value="{{ value }}" <# if ( value == data.value ){ print('checked'); } #>>{{ label }}<br />
 		<# }); #>
@@ -75,7 +75,7 @@
 	<div class="field-block">
 		<label for="{{ data.attr }}">
 			<input type="checkbox" name="{{ data.attr }}" id="{{ data.attr }}" value="{{ data.value }}" <# if ( 'true' == data.value ){ print('checked'); } #>>
-			{{ data.label }}
+			{{ data.label }}<# if ( data.required == true ) { #> *<# } #>
 		</label>
 		<# if ( typeof data.description == 'string' ) { #>
 			<p class="description">{{ data.description }}</p>
@@ -85,8 +85,8 @@
 
 <script type="text/html" id="tmpl-shortcode-ui-field-email">
 	<div class="field-block">
-		<label for="{{ data.attr }}">{{ data.label }}</label>
-		<input type="email" name="{{ data.attr }}" id="{{ data.attr }}" value="{{ data.value}}" placeholder="{{ data.placeholder }}"/>
+		<label for="{{ data.attr }}">{{ data.label }}<# if ( data.required == true ) { #> *<# } #></label>
+		<input type="email" name="{{ data.attr }}" id="{{ data.attr }}" value="{{ data.value}}" size="{{ data.size }}" placeholder="{{ data.placeholder }}"/>
 		<# if ( typeof data.description == 'string' ) { #>
 			<p class="description">{{ data.description }}</p>
 		<# } #>
@@ -95,8 +95,8 @@
 
 <script type="text/html" id="tmpl-shortcode-ui-field-number">
 	<div class="field-block">
-		<label for="{{ data.attr }}">{{ data.label }}</label>
-		<input type="number" name="{{ data.attr }}" id="{{ data.attr }}" value="{{ data.value}}" placeholder="{{ data.placeholder }}"/>
+		<label for="{{ data.attr }}">{{ data.label }}<# if ( data.required == true ) { #> *<# } #></label>
+		<input type="number" name="{{ data.attr }}" id="{{ data.attr }}" value="{{ data.value}}" size="{{ data.size }}" placeholder="{{ data.placeholder }}"/>
 		<# if ( typeof data.description == 'string' ) { #>
 			<p class="description">{{ data.description }}</p>
 		<# } #>
@@ -115,7 +115,7 @@
 
 <script type="text/html" id="tmpl-shortcode-ui-field-date">
 	<div class="field-block">
-		<label for="{{ data.attr }}">{{ data.label }}</label>
+		<label for="{{ data.attr }}">{{ data.label }}<# if ( data.required == true ) { #> *<# } #></label>
 		<input type="date" name="{{ data.attr }}" id="{{ data.attr }}" value="{{ data.value }}" placeholder="{{ data.placeholder }}"/>
 		<# if ( typeof data.description == 'string' ) { #>
 			<p class="description">{{ data.description }}</p>
@@ -125,8 +125,8 @@
 
 <script type="text/html" id="tmpl-shortcode-ui-content">
 	<div class="field-block">
-		<label for="inner_content">{{ data.label }}</label>
-		<textarea id="inner_content" name="inner_content" class="content-edit">{{ data.value }}</textarea>
+		<label for="inner_content">{{ data.label }}<# if ( data.required == true ) { #> *<# } #></label>
+		<textarea id="inner_content" name="inner_content" cols="{{ data.cols }}" rows="{{ data.rows }}" class="content-edit">{{ data.value }}</textarea>
 		<# if ( typeof data.description == 'string' ) { #>
 			<p class="description">{{ data.description }}</p>
 		<# } #>

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -413,13 +413,19 @@ var shortcodeViewConstructor = {
 		currentShortcode = defaultShortcode.clone();
 
 		if ( matches[2] ) {
+			// Use the regex from the WordPress do_shortcode() parser.
+			var attributeRegex = /(\w+)\s*=\s*"([^"]*)"(?:\s|$)|(\w+)\s*=\s*'([^']*)'(?:\s|$)|(\w+)\s*=\s*([^\s'"]+)(?:\s|$)|"([^"]*)"(?:\s|$)|(\S+)(?:\s|$)/gmi;
+			attributeMatches = matches[2].match( attributeRegex ) || [];
 
-			attributeMatches = matches[2].match( /(\S+?=".*?")/g ) || [];
+			// Get rid of any extra spaces at the end of the matches.
+			for(var i in attributeMatches){
+				attributeMatches[i] = attributeMatches[i].replace(/^\s+|\s+$/g,'');
+			}
 
 			// convert attribute strings to object.
 			for ( var i = 0; i < attributeMatches.length; i++ ) {
 
-				var bitsRegEx = /(\S+?)="(.*?)"/g;
+				var bitsRegEx = /(\S+?)=(.*)/g;
 				var bits = bitsRegEx.exec( attributeMatches[i] );
 
 				attr = currentShortcode.get( 'attrs' ).findWhere({
@@ -427,7 +433,18 @@ var shortcodeViewConstructor = {
 				});
 
 				if ( attr ) {
-					attr.set('value', bits[2]);
+					// Make a copy of the result to strip any quotation marks off of.
+					var val = bits[2];
+					
+					// Remove a quotation mark at the beginning of the string.
+					val = val.replace( /^"/, '' );
+					
+					// Check to see if we actually removed a quotation mark, if so then we have to remove the one at the end.  If not then we don't have to as if there is a quotation mark at the end it is part of the data.
+					if( val != bits[2] ) {
+						val = val.replace( /"$/, '' );
+					}
+					
+					attr.set('value', val);
 				}
 
 			}

--- a/js/utils/shortcode-view-constructor.js
+++ b/js/utils/shortcode-view-constructor.js
@@ -154,13 +154,19 @@ var shortcodeViewConstructor = {
 		currentShortcode = defaultShortcode.clone();
 
 		if ( matches[2] ) {
+			// Use the regex from the WordPress do_shortcode() parser.
+			var attributeRegex = /(\w+)\s*=\s*"([^"]*)"(?:\s|$)|(\w+)\s*=\s*'([^']*)'(?:\s|$)|(\w+)\s*=\s*([^\s'"]+)(?:\s|$)|"([^"]*)"(?:\s|$)|(\S+)(?:\s|$)/gmi;
+			attributeMatches = matches[2].match( attributeRegex ) || [];
 
-			attributeMatches = matches[2].match( /(\S+?=".*?")/g ) || [];
+			// Get rid of any extra spaces at the end of the matches.
+			for(var i in attributeMatches){
+				attributeMatches[i] = attributeMatches[i].replace(/^\s+|\s+$/g,'');
+			}
 
 			// convert attribute strings to object.
 			for ( var i = 0; i < attributeMatches.length; i++ ) {
 
-				var bitsRegEx = /(\S+?)="(.*?)"/g;
+				var bitsRegEx = /(\S+?)=(.*)/g;
 				var bits = bitsRegEx.exec( attributeMatches[i] );
 
 				attr = currentShortcode.get( 'attrs' ).findWhere({
@@ -168,7 +174,18 @@ var shortcodeViewConstructor = {
 				});
 
 				if ( attr ) {
-					attr.set('value', bits[2]);
+					// Make a copy of the result to strip any quotation marks off of.
+					var val = bits[2];
+					
+					// Remove a quotation mark at the beginning of the string.
+					val = val.replace( /^"/, '' );
+					
+					// Check to see if we actually removed a quotation mark, if so then we have to remove the one at the end.  If not then we don't have to as if there is a quotation mark at the end it is part of the data.
+					if( val != bits[2] ) {
+						val = val.replace( /"$/, '' );
+					}
+					
+					attr.set('value', val);
 				}
 
 			}


### PR DESCRIPTION
- Attributes without quotation marks are parsed correctly.
- New template options to control the size, rows, cols of the input fields.
- New template option for required fields to add an asterisk after the label (should probably add some javascript to block the update call without having values).
