### PR TITLE
Remove backwards compat shim for `content`

### DIFF
--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -43,6 +43,10 @@ class Shortcode_UI {
 			);
 		}
 
+		if ( ! isset( $args['attrs'] ) ) {
+			$args['attrs'] = array();
+		}
+
 		$args['shortcode_tag'] = $shortcode_tag;
 		$this->shortcodes[ $shortcode_tag ] = $args;
 

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -43,28 +43,6 @@ class Shortcode_UI {
 			);
 		}
 
-		//following code is for backward compatibility
-		//which will be removed in the next version. (to supports 'attr' => 'content' special case)
-		for ( $i = 0; $i < count( $args['attrs'] ); $i++ ) {
-
-			if ( ! isset( $args['attrs'][ $i ]['attr'] ) || $args['attrs'][ $i ]['attr'] !== 'content' ) {
-				continue;
-			}
-
-			$args['inner_content'] = array();
-			foreach ( $args['attrs'][ $i ] as $key => $value ) {
-				if ( $key == 'attr' ) {
-					continue;
-				}
-				$args['inner_content'][ $key ] = $value;
-			}
-
-			$index = $i;
-		}
-		if ( isset( $index ) ) {
-			array_splice( $args['attrs'], $index, 1 );
-		}
-
 		$args['shortcode_tag'] = $shortcode_tag;
 		$this->shortcodes[ $shortcode_tag ] = $args;
 


### PR DESCRIPTION
This will let `content become an argument in its own right
