### PR TITLE
don't apply fix for master to the 4.1.1 compat

### DIFF
--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -721,11 +721,11 @@ var shortcodeViewConstructor = {
 						self.setIframes( self.getEditorStyles(), response );
 					} else {
 						self.parsed = response;
-						self.render();
+						self.render( true );
 					}
 				}).fail( function() {
 					self.parsed = '<span class="shortcake-error">' + shortcodeUIData.strings.mce_view_error + '</span>';
-					self.render();
+					self.render( true );
 				} );
 
 			}

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -504,11 +504,11 @@ var shortcodeViewConstructor = {
 						self.setIframes( self.getEditorStyles(), response );
 					} else {
 						self.parsed = response;
-						self.render();
+						self.render( true );
 					}
 				}).fail( function() {
 					self.parsed = '<span class="shortcake-error">' + shortcodeUIData.strings.mce_view_error + '</span>';
-					self.render();
+					self.render( true );
 				} );
 
 			}

--- a/js/utils/shortcode-view-constructor.js
+++ b/js/utils/shortcode-view-constructor.js
@@ -244,11 +244,11 @@ var shortcodeViewConstructor = {
 						self.setIframes( self.getEditorStyles(), response );
 					} else {
 						self.parsed = response;
-						self.render();
+						self.render( true );
 					}
 				}).fail( function() {
 					self.parsed = '<span class="shortcake-error">' + shortcodeUIData.strings.mce_view_error + '</span>';
-					self.render();
+					self.render( true );
 				} );
 
 			}


### PR DESCRIPTION
The changes here were done keep up with changes to MCE Views in WP trunk. https://github.com/fusioneng/Shortcake/commit/9005e709454fd25d8346e445a5be07fca5f81267 

However I was a bit overzelous in applying this fix to the code for 4.1.1 compatability. 

Reverting this fixes 4.1.1

See #267 
