### PR TITLE
Adds .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# http://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[*.json]
+indent_style = space
+indent_size = 2
+
+[*.txt,wp-config-sample.php]
+end_of_line = crlf


### PR DESCRIPTION
Includes WP core's .editorconfig file to enforce uniform style among contributors,
