### PR TITLE
Support registering shortcode UI for specific post types

### DIFF
--- a/dev.php
+++ b/dev.php
@@ -78,6 +78,8 @@ add_action( 'init', function() {
 				'label' => 'Quote',
 			),
 
+			'post_type'     => array( 'post' ),
+
 			// Available shortcode attributes and default values. Required. Array.
 			// Attribute model expects 'attr', 'type' and 'label'
 			// Supported field types: text, checkbox, textarea, radio, select, email, url, number, and date.

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -78,6 +78,19 @@ class Shortcode_UI {
 		wp_enqueue_media();
 
 		$shortcodes = array_values( $this->shortcodes );
+		$screen = get_current_screen();
+		if ( $screen && ! empty( $screen->post_type ) ) {
+			foreach( $shortcodes as $key => $args ) {
+				if ( ! empty( $args['post_type'] ) && ! in_array( $screen->post_type, $args['post_type'] ) ) {
+					unset( $shortcodes[ $key ] );
+				}
+			}
+		}
+
+		if ( empty( $shortcodes ) ) {
+			return;
+		}
+
 		usort( $shortcodes, array( $this, 'compare_shortcodes_by_label' ) );
 
 		wp_enqueue_script( 'shortcode-ui', $this->plugin_url . 'js/build/shortcode-ui.js', array( 'jquery', 'backbone', 'mce-view' ), $this->plugin_version );


### PR DESCRIPTION
If `post_type` argument is present and doesn't match `get_current_screen()`, the shortcode UI won't appear.

Changes behavior to hide Shortcake entirely if there isn't any registered UI.

Fixes #148
