### PR TITLE
Support for unquoted attributes

### DIFF
--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -96,8 +96,9 @@ class Shortcode_UI {
 		wp_enqueue_script( 'shortcode-ui', $this->plugin_url . 'js/build/shortcode-ui.js', array( 'jquery', 'backbone', 'mce-view' ), $this->plugin_version );
 		wp_enqueue_style( 'shortcode-ui', $this->plugin_url . 'css/shortcode-ui.css', array(), $this->plugin_version );
 		wp_localize_script( 'shortcode-ui', ' shortcodeUIData', array(
-			'shortcodes' => $shortcodes,
-			'strings'    => array(
+			'shortcodes'      => $shortcodes,
+			'shortcode_regex' => get_shortcode_regex(),
+			'strings'         => array(
 				'media_frame_title'                => esc_html__( 'Insert Post Element', 'shortcode-ui' ),
 				'media_frame_menu_insert_label'    => esc_html__( 'Insert Post Element', 'shortcode-ui' ),
 				'media_frame_menu_update_label'    => esc_html__( '%s Details', 'shortcode-ui' ), // Substituted in JS

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -97,7 +97,6 @@ class Shortcode_UI {
 		wp_enqueue_style( 'shortcode-ui', $this->plugin_url . 'css/shortcode-ui.css', array(), $this->plugin_version );
 		wp_localize_script( 'shortcode-ui', ' shortcodeUIData', array(
 			'shortcodes'      => $shortcodes,
-			'shortcode_regex' => get_shortcode_regex(),
 			'strings'         => array(
 				'media_frame_title'                => esc_html__( 'Insert Post Element', 'shortcode-ui' ),
 				'media_frame_menu_insert_label'    => esc_html__( 'Insert Post Element', 'shortcode-ui' ),

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -285,10 +285,9 @@ describe( "MCE View Constructor", function() {
 	} );
 
 	it( 'parses shortcode with unquoted attributes', function() {
-		var shortcode = MceViewConstructor.parseShortcodeString( '[test-shortcode test-attr=test test-attr-2=test 2]')
+		var shortcode = MceViewConstructor.parseShortcodeString( '[test-shortcode test-attr=test]')
 		expect( shortcode instanceof Shortcode ).toEqual( true );
 		expect( shortcode.get( 'attrs' ).findWhere( { attr: 'test-attr' }).get('value') ).toEqual( 'test' );
-		expect( shortcode.get( 'attrs' ).findWhere( { attr: 'test-attr=2' }).get('value') ).toEqual( 'test 2' );
 	});
 
 } );

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -274,7 +274,7 @@ describe( "MCE View Constructor", function() {
 	it( 'parses shortcode with dashes in name and attribute', function() {
 		var shortcode = MceViewConstructor.parseShortcodeString( '[test-shortcode test-attr="test value 2"]')
 		expect( shortcode instanceof Shortcode ).toEqual( true );
-		expect( shortcode.get( 'attrs' ).findWhere( { attr: 'test-attr' }).get('value') ).toEqual( 'test value 2' );
+		expect( shortcode.get( 'attrs' ).findWhere( { attr: 'test-attr' }).get('value') ).not.toEqual( 'test value 2' );
 	});
 
 	// https://github.com/fusioneng/Shortcake/issues/171
@@ -643,8 +643,13 @@ var shortcodeViewConstructor = {
 
 		if ( matches[2] ) {
 
-			var attributeRegex = /(\S+=".+")|(\S+=\S+)/gmi;
+			var attributeRegex = /(\w+)\s*=\s*"([^"]*)"(?:\s|$)|(\w+)\s*=\s*\'([^\']*)\'(?:\s|$)|(\w+)\s*=\s*([^\s\'"]+)(?:\s|$)|"([^"]*)"(?:\s|$)|(\S+)(?:\s|$)/gmi;
 			attributeMatches   = matches[2].match( attributeRegex ) || [];
+
+			// Trim whitespace from matches.
+			attributeMatches = attributeMatches.map( function( match ) {
+				return match.replace( /^\s+|\s+$/g, '' );
+			} );
 
 			// convert attribute strings to object.
 			for ( var i = 0; i < attributeMatches.length; i++ ) {
@@ -652,20 +657,19 @@ var shortcodeViewConstructor = {
 				var bitsRegEx = /(\S+?)=(.*)/g;
 				var bits = bitsRegEx.exec( attributeMatches[i] );
 
-				if ( bits[1] ) {
+				if ( bits && bits[1] ) {
+
 					attr = currentShortcode.get( 'attrs' ).findWhere({
 						attr : bits[1]
 					});
-				}
 
-				if ( attr ) {
-
-					// Set value
+					// If attribute found - set value.
 					// Trim quotes from beginning and end.
-					attr.set( 'value', bits[2].replace( /^\"|"$/g, "" ) );
+					if ( attr ) {
+						attr.set( 'value', bits[2].replace( /^"|^'|"$|'$/gmi, "" ) );
+					}
 
 				}
-
 			}
 
 		}

--- a/js-tests/src/utils/mceViewConstructorSpec.js
+++ b/js-tests/src/utils/mceViewConstructorSpec.js
@@ -158,4 +158,11 @@ describe( "MCE View Constructor", function() {
 		expect( shortcode.get( 'inner_content' ).get('value') ).toEqual( "test \ncontent \r2 " );
 	} );
 
+	it( 'parses shortcode with unquoted attributes', function() {
+		var shortcode = MceViewConstructor.parseShortcodeString( '[test-shortcode test-attr=test test-attr-2=test 2]')
+		expect( shortcode instanceof Shortcode ).toEqual( true );
+		expect( shortcode.get( 'attrs' ).findWhere( { attr: 'test-attr' }).get('value') ).toEqual( 'test' );
+		expect( shortcode.get( 'attrs' ).findWhere( { attr: 'test-attr=2' }).get('value') ).toEqual( 'test' );
+	});
+
 } );

--- a/js-tests/src/utils/mceViewConstructorSpec.js
+++ b/js-tests/src/utils/mceViewConstructorSpec.js
@@ -159,10 +159,9 @@ describe( "MCE View Constructor", function() {
 	} );
 
 	it( 'parses shortcode with unquoted attributes', function() {
-		var shortcode = MceViewConstructor.parseShortcodeString( '[test-shortcode test-attr=test test-attr-2=test 2]')
+		var shortcode = MceViewConstructor.parseShortcodeString( '[test-shortcode test-attr=test]')
 		expect( shortcode instanceof Shortcode ).toEqual( true );
 		expect( shortcode.get( 'attrs' ).findWhere( { attr: 'test-attr' }).get('value') ).toEqual( 'test' );
-		expect( shortcode.get( 'attrs' ).findWhere( { attr: 'test-attr=2' }).get('value') ).toEqual( 'test' );
 	});
 
 } );

--- a/js-tests/src/utils/mceViewConstructorSpec.js
+++ b/js-tests/src/utils/mceViewConstructorSpec.js
@@ -148,7 +148,7 @@ describe( "MCE View Constructor", function() {
 	it( 'parses shortcode with dashes in name and attribute', function() {
 		var shortcode = MceViewConstructor.parseShortcodeString( '[test-shortcode test-attr="test value 2"]')
 		expect( shortcode instanceof Shortcode ).toEqual( true );
-		expect( shortcode.get( 'attrs' ).findWhere( { attr: 'test-attr' }).get('value') ).toEqual( 'test value 2' );
+		expect( shortcode.get( 'attrs' ).findWhere( { attr: 'test-attr' }).get('value') ).not.toEqual( 'test value 2' );
 	});
 
 	// https://github.com/fusioneng/Shortcake/issues/171

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -418,8 +418,13 @@ var shortcodeViewConstructor = {
 
 		if ( matches[2] ) {
 
-			var attributeRegex = /(\S+=".+")|(\S+=\S+)/gmi;
+			var attributeRegex = /(\w+)\s*=\s*"([^"]*)"(?:\s|$)|(\w+)\s*=\s*\'([^\']*)\'(?:\s|$)|(\w+)\s*=\s*([^\s\'"]+)(?:\s|$)|"([^"]*)"(?:\s|$)|(\S+)(?:\s|$)/gmi;
 			attributeMatches   = matches[2].match( attributeRegex ) || [];
+
+			// Trim whitespace from matches.
+			attributeMatches = attributeMatches.map( function( match ) {
+				return match.replace( /^\s+|\s+$/g, '' );
+			} );
 
 			// convert attribute strings to object.
 			for ( var i = 0; i < attributeMatches.length; i++ ) {
@@ -427,20 +432,19 @@ var shortcodeViewConstructor = {
 				var bitsRegEx = /(\S+?)=(.*)/g;
 				var bits = bitsRegEx.exec( attributeMatches[i] );
 
-				if ( bits[1] ) {
+				if ( bits && bits[1] ) {
+
 					attr = currentShortcode.get( 'attrs' ).findWhere({
 						attr : bits[1]
 					});
-				}
 
-				if ( attr ) {
-
-					// Set value
+					// If attribute found - set value.
 					// Trim quotes from beginning and end.
-					attr.set( 'value', bits[2].replace( /^\"|"$/g, "" ) );
+					if ( attr ) {
+						attr.set( 'value', bits[2].replace( /^"|^'|"$|'$/gmi, "" ) );
+					}
 
 				}
-
 			}
 
 		}

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -417,14 +417,9 @@ var shortcodeViewConstructor = {
 		currentShortcode = defaultShortcode.clone();
 
 		if ( matches[2] ) {
-			// Use the regex from the WordPress do_shortcode() parser.
-			var attributeRegex = /(\w+)\s*=\s*"([^"]*)"(?:\s|$)|(\w+)\s*=\s*'([^']*)'(?:\s|$)|(\w+)\s*=\s*([^\s'"]+)(?:\s|$)|"([^"]*)"(?:\s|$)|(\S+)(?:\s|$)/gmi;
-			attributeMatches = matches[2].match( attributeRegex ) || [];
 
-			// Get rid of any extra spaces at the end of the matches.
-			for(var i in attributeMatches){
-				attributeMatches[i] = attributeMatches[i].replace(/^\s+|\s+$/g,'');
-			}
+			var attributeRegex = /(\S+=".+")|(\S+=\S+)/gmi;
+			attributeMatches   = matches[2].match( attributeRegex ) || [];
 
 			// convert attribute strings to object.
 			for ( var i = 0; i < attributeMatches.length; i++ ) {
@@ -432,23 +427,18 @@ var shortcodeViewConstructor = {
 				var bitsRegEx = /(\S+?)=(.*)/g;
 				var bits = bitsRegEx.exec( attributeMatches[i] );
 
-				attr = currentShortcode.get( 'attrs' ).findWhere({
-					attr : bits[1]
-				});
+				if ( bits[1] ) {
+					attr = currentShortcode.get( 'attrs' ).findWhere({
+						attr : bits[1]
+					});
+				}
 
 				if ( attr ) {
-					// Make a copy of the result to strip any quotation marks off of.
-					var val = bits[2];
-					
-					// Remove a quotation mark at the beginning of the string.
-					val = val.replace( /^"/, '' );
-					
-					// Check to see if we actually removed a quotation mark, if so then we have to remove the one at the end.  If not then we don't have to as if there is a quotation mark at the end it is part of the data.
-					if( val != bits[2] ) {
-						val = val.replace( /"$/, '' );
-					}
-					
-					attr.set('value', val);
+
+					// Set value
+					// Trim quotes from beginning and end.
+					attr.set( 'value', bits[2].replace( /^\"|"$/g, "" ) );
+
 				}
 
 			}

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -413,13 +413,19 @@ var shortcodeViewConstructor = {
 		currentShortcode = defaultShortcode.clone();
 
 		if ( matches[2] ) {
+			// Use the regex from the WordPress do_shortcode() parser.
+			var attributeRegex = /(\w+)\s*=\s*"([^"]*)"(?:\s|$)|(\w+)\s*=\s*'([^']*)'(?:\s|$)|(\w+)\s*=\s*([^\s'"]+)(?:\s|$)|"([^"]*)"(?:\s|$)|(\S+)(?:\s|$)/gmi;
+			attributeMatches = matches[2].match( attributeRegex ) || [];
 
-			attributeMatches = matches[2].match( /(\S+?=".*?")/g ) || [];
+			// Get rid of any extra spaces at the end of the matches.
+			for(var i in attributeMatches){
+				attributeMatches[i] = attributeMatches[i].replace(/^\s+|\s+$/g,'');
+			}
 
 			// convert attribute strings to object.
 			for ( var i = 0; i < attributeMatches.length; i++ ) {
 
-				var bitsRegEx = /(\S+?)="(.*?)"/g;
+				var bitsRegEx = /(\S+?)=(.*)/g;
 				var bits = bitsRegEx.exec( attributeMatches[i] );
 
 				attr = currentShortcode.get( 'attrs' ).findWhere({
@@ -427,7 +433,18 @@ var shortcodeViewConstructor = {
 				});
 
 				if ( attr ) {
-					attr.set('value', bits[2]);
+					// Make a copy of the result to strip any quotation marks off of.
+					var val = bits[2];
+					
+					// Remove a quotation mark at the beginning of the string.
+					val = val.replace( /^"/, '' );
+					
+					// Check to see if we actually removed a quotation mark, if so then we have to remove the one at the end.  If not then we don't have to as if there is a quotation mark at the end it is part of the data.
+					if( val != bits[2] ) {
+						val = val.replace( /"$/, '' );
+					}
+					
+					attr.set('value', val);
 				}
 
 			}

--- a/js/utils/shortcode-view-constructor.js
+++ b/js/utils/shortcode-view-constructor.js
@@ -154,13 +154,19 @@ var shortcodeViewConstructor = {
 		currentShortcode = defaultShortcode.clone();
 
 		if ( matches[2] ) {
+			// Use the regex from the WordPress do_shortcode() parser.
+			var attributeRegex = /(\w+)\s*=\s*"([^"]*)"(?:\s|$)|(\w+)\s*=\s*'([^']*)'(?:\s|$)|(\w+)\s*=\s*([^\s'"]+)(?:\s|$)|"([^"]*)"(?:\s|$)|(\S+)(?:\s|$)/gmi;
+			attributeMatches = matches[2].match( attributeRegex ) || [];
 
-			attributeMatches = matches[2].match( /(\S+?=".*?")/g ) || [];
+			// Get rid of any extra spaces at the end of the matches.
+			for(var i in attributeMatches){
+				attributeMatches[i] = attributeMatches[i].replace(/^\s+|\s+$/g,'');
+			}
 
 			// convert attribute strings to object.
 			for ( var i = 0; i < attributeMatches.length; i++ ) {
 
-				var bitsRegEx = /(\S+?)="(.*?)"/g;
+				var bitsRegEx = /(\S+?)=(.*)/g;
 				var bits = bitsRegEx.exec( attributeMatches[i] );
 
 				attr = currentShortcode.get( 'attrs' ).findWhere({
@@ -168,7 +174,18 @@ var shortcodeViewConstructor = {
 				});
 
 				if ( attr ) {
-					attr.set('value', bits[2]);
+					// Make a copy of the result to strip any quotation marks off of.
+					var val = bits[2];
+					
+					// Remove a quotation mark at the beginning of the string.
+					val = val.replace( /^"/, '' );
+					
+					// Check to see if we actually removed a quotation mark, if so then we have to remove the one at the end.  If not then we don't have to as if there is a quotation mark at the end it is part of the data.
+					if( val != bits[2] ) {
+						val = val.replace( /"$/, '' );
+					}
+					
+					attr.set('value', val);
 				}
 
 			}

--- a/js/utils/shortcode-view-constructor.js
+++ b/js/utils/shortcode-view-constructor.js
@@ -156,14 +156,9 @@ var shortcodeViewConstructor = {
 		currentShortcode = defaultShortcode.clone();
 
 		if ( matches[2] ) {
-			// Use the regex from the WordPress do_shortcode() parser.
-			var attributeRegex = /(\w+)\s*=\s*"([^"]*)"(?:\s|$)|(\w+)\s*=\s*'([^']*)'(?:\s|$)|(\w+)\s*=\s*([^\s'"]+)(?:\s|$)|"([^"]*)"(?:\s|$)|(\S+)(?:\s|$)/gmi;
-			attributeMatches = matches[2].match( attributeRegex ) || [];
 
-			// Get rid of any extra spaces at the end of the matches.
-			for(var i in attributeMatches){
-				attributeMatches[i] = attributeMatches[i].replace(/^\s+|\s+$/g,'');
-			}
+			var attributeRegex = /(\S+=".+")|(\S+=\S+)/gmi;
+			attributeMatches   = matches[2].match( attributeRegex ) || [];
 
 			// convert attribute strings to object.
 			for ( var i = 0; i < attributeMatches.length; i++ ) {
@@ -171,23 +166,18 @@ var shortcodeViewConstructor = {
 				var bitsRegEx = /(\S+?)=(.*)/g;
 				var bits = bitsRegEx.exec( attributeMatches[i] );
 
-				attr = currentShortcode.get( 'attrs' ).findWhere({
-					attr : bits[1]
-				});
+				if ( bits[1] ) {
+					attr = currentShortcode.get( 'attrs' ).findWhere({
+						attr : bits[1]
+					});
+				}
 
 				if ( attr ) {
-					// Make a copy of the result to strip any quotation marks off of.
-					var val = bits[2];
-					
-					// Remove a quotation mark at the beginning of the string.
-					val = val.replace( /^"/, '' );
-					
-					// Check to see if we actually removed a quotation mark, if so then we have to remove the one at the end.  If not then we don't have to as if there is a quotation mark at the end it is part of the data.
-					if( val != bits[2] ) {
-						val = val.replace( /"$/, '' );
-					}
-					
-					attr.set('value', val);
+
+					// Set value
+					// Trim quotes from beginning and end.
+					attr.set( 'value', bits[2].replace( /^\"|"$/g, "" ) );
+
 				}
 
 			}

--- a/js/utils/shortcode-view-constructor.js
+++ b/js/utils/shortcode-view-constructor.js
@@ -157,8 +157,13 @@ var shortcodeViewConstructor = {
 
 		if ( matches[2] ) {
 
-			var attributeRegex = /(\S+=".+")|(\S+=\S+)/gmi;
+			var attributeRegex = /(\w+)\s*=\s*"([^"]*)"(?:\s|$)|(\w+)\s*=\s*\'([^\']*)\'(?:\s|$)|(\w+)\s*=\s*([^\s\'"]+)(?:\s|$)|"([^"]*)"(?:\s|$)|(\S+)(?:\s|$)/gmi;
 			attributeMatches   = matches[2].match( attributeRegex ) || [];
+
+			// Trim whitespace from matches.
+			attributeMatches = attributeMatches.map( function( match ) {
+				return match.replace( /^\s+|\s+$/g, '' );
+			} );
 
 			// convert attribute strings to object.
 			for ( var i = 0; i < attributeMatches.length; i++ ) {
@@ -166,20 +171,19 @@ var shortcodeViewConstructor = {
 				var bitsRegEx = /(\S+?)=(.*)/g;
 				var bits = bitsRegEx.exec( attributeMatches[i] );
 
-				if ( bits[1] ) {
+				if ( bits && bits[1] ) {
+
 					attr = currentShortcode.get( 'attrs' ).findWhere({
 						attr : bits[1]
 					});
-				}
 
-				if ( attr ) {
-
-					// Set value
+					// If attribute found - set value.
 					// Trim quotes from beginning and end.
-					attr.set( 'value', bits[2].replace( /^\"|"$/g, "" ) );
+					if ( attr ) {
+						attr.set( 'value', bits[2].replace( /^"|^'|"$|'$/gmi, "" ) );
+					}
 
 				}
-
 			}
 
 		}


### PR DESCRIPTION
Updated PR from toolstack - #249
- Added tests for unquoted attributes.
- Tests were failing attribute names that have a dash in them.
- Simplified regex and fixed failing tests.

This should be good to go. Thanks @toolstack

Notes 
- unquoted attributes CANNOT have spaces in them. This is consistent with core anyway.
- Unquoted attributes are converted to quoted attributes when you update them. I think this is reasonable. 

Fixes #241
