### PR TITLE
Prevent unnecessary coupling with TinyMCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Once you've done so, you'll need to [register the UI for your code](https://gith
 ### 0.3 (???) ###
 * Shows a helpful message when a shortcode doesn't have attributes to configure.
 * Example plugin can be activated through the WordPress admin.
+* Bug fix: "Insert Post Element" experience should work when visual editor is disabled. Shortcake is only loosely coupled with TinyMCE.
 
 ### 0.2.3 (April 8, 2015) ###
 * Fix WP 4.1 backwards compatibility issue by restoring arguments passed to TinyMCE view compatibility shim.

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -1051,8 +1051,10 @@ var ShortcodePreview = Backbone.View.extend({
 
 		_.defaults( params || {}, { 'head': '', 'body': '', 'body_classes': 'shortcake shortcake-preview' });
 
+		var isIE = typeof tinymce != 'undefined' ? tinymce.Env.ie : false;
+
 		$iframe = $( '<iframe/>', {
-			src: tinymce.Env.ie ? 'javascript:""' : '',
+			src: isIE ? 'javascript:""' : '',
 			frameBorder: '0',
 			allowTransparency: 'true',
 			scrolling: 'no',
@@ -1152,7 +1154,8 @@ var ShortcodePreview = Backbone.View.extend({
 	getEditorStyles: function() {
 		var styles = {};
 
-		_.each( tinymce.editors, function( editor ) {
+		var editors = typeof tinymce != 'undefined' ? tinymce.editors : [];
+		_.each( editors, function( editor ) {
 			_.each( editor.dom.$( 'link[rel="stylesheet"]', editor.getDoc().head ), function( link ) {
 				var href;
 				( href = link.href ) && ( styles[href] = true );	// Poor man's de-duping.

--- a/js/views/shortcode-preview.js
+++ b/js/views/shortcode-preview.js
@@ -62,8 +62,10 @@ var ShortcodePreview = Backbone.View.extend({
 
 		_.defaults( params || {}, { 'head': '', 'body': '', 'body_classes': 'shortcake shortcake-preview' });
 
+		var isIE = typeof tinymce != 'undefined' ? tinymce.Env.ie : false;
+
 		$iframe = $( '<iframe/>', {
-			src: tinymce.Env.ie ? 'javascript:""' : '',
+			src: isIE ? 'javascript:""' : '',
 			frameBorder: '0',
 			allowTransparency: 'true',
 			scrolling: 'no',
@@ -163,7 +165,8 @@ var ShortcodePreview = Backbone.View.extend({
 	getEditorStyles: function() {
 		var styles = {};
 
-		_.each( tinymce.editors, function( editor ) {
+		var editors = typeof tinymce != 'undefined' ? tinymce.editors : [];
+		_.each( editors, function( editor ) {
 			_.each( editor.dom.$( 'link[rel="stylesheet"]', editor.getDoc().head ), function( link ) {
 				var href;
 				( href = link.href ) && ( styles[href] = true );	// Poor man's de-duping.

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,7 @@ Once you've done so, you'll need to [register the UI for your code](https://gith
 = 0.3 (???) =
 * Shows a helpful message when a shortcode doesn't have attributes to configure.
 * Example plugin can be activated through the WordPress admin.
+* Bug fix: "Insert Post Element" experience should work when visual editor is disabled. Shortcake is only loosely coupled with TinyMCE.
 
 = 0.2.3 (April 8, 2015) =
 * Fix WP 4.1 backwards compatibility issue by restoring arguments passed to TinyMCE view compatibility shim.


### PR DESCRIPTION
If TinyMCE is unavailable, we'd still like Shortcake to work with the media library

Fixes #234
