### PR TITLE
Force MCE view render

### DIFF
--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -555,7 +555,7 @@ var shortcodeViewConstructor = {
 				self.content = '<span class="shortcake-error">' + shortcodeUIData.strings.mce_view_error + '</span>';
 			} ).always( function() {
 				delete self.fetching;
-				self.render();
+				self.render( null, true );
 			} );
 
 		}

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -345,7 +345,7 @@ var shortcodeViewConstructor = {
 				self.content = '<span class="shortcake-error">' + shortcodeUIData.strings.mce_view_error + '</span>';
 			} ).always( function() {
 				delete self.fetching;
-				self.render();
+				self.render( null, true );
 			} );
 
 		}

--- a/js/src/utils/shortcode-view-constructor.js
+++ b/js/src/utils/shortcode-view-constructor.js
@@ -81,7 +81,7 @@ var shortcodeViewConstructor = {
 				self.content = '<span class="shortcake-error">' + shortcodeUIData.strings.mce_view_error + '</span>';
 			} ).always( function() {
 				delete self.fetching;
-				self.render();
+				self.render( null, true );
 			} );
 
 		}


### PR DESCRIPTION
Fixes #300 

This bug was introduced when we added compatability for the changes to MCE views introduced in WP 4.2

Previously - we called `render( true ) // force`

However in 4.2, the first param is the content, the second param is force (bool). This was changed. 

This plugin reverts this change - the behaviour should be the same as 0.2 on WP 4.1
