### PR TITLE
Allow shortcode ui to register default values for attrs

### DIFF
--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -33,20 +33,39 @@ var ShortcodeAttribute = require('../../js/src/models/shortcode-attribute');
 describe( "Shortcode Attribute Model", function() {
 
 	var attrData = {
-		attr:        'attr',
-		label:       'Attribute',
-		type:        'text',
-		value:       'test value',
-		description: 'test description',
+		attr:           'attr',
+		label:          'Attribute',
+		type:           'text',
+		value:          'test value',
+		description:    'test description',
 		meta:  {
 			placeholder: 'test placeholder'
 		}
-	};
+	},
+	expectedAttrData = _.extend( attrData, { default_value: '' });
 
 	var attr = new ShortcodeAttribute( attrData );
 
 	it( 'should correctly set data.', function() {
-		expect( attr.toJSON() ).toEqual( attrData );
+		expect( attr.toJSON() ).toEqual( expectedAttrData );
+	});
+
+	var attrData = {
+		attr:           'attr',
+		label:          'Attribute',
+		type:           'text',
+		default_value:  'test value',
+		description:    'test description',
+		meta:  {
+			placeholder: 'test placeholder'
+		}
+	},
+	expectedAttrData = _.extend( attrData, { value: 'test_value' });
+
+	var attr = new ShortcodeAttribute( attrData );
+
+	it( 'should correctly apply default values to shortcode attributes.', function() {
+		expect( attr.toJSON() ).toEqual( expectedAttrData );
 	});
 
 
@@ -354,11 +373,12 @@ var Backbone = (typeof window !== "undefined" ? window.Backbone : typeof global 
 
 var ShortcodeAttribute = Backbone.Model.extend({
 	defaults: {
-		attr:        '',
-		label:       '',
-		type:        '',
-		value:       '',
-		description: '',
+		attr:          '',
+		label:         '',
+		type:          '',
+		value:         '',
+		default_value: '',
+		description:   '',
 		meta: {
 			placeholder: '',
 		}
@@ -509,6 +529,13 @@ var shortcodeViewConstructor = {
 					attr.set(
 						'value',
 						options.attrs.named[ attr.get('attr') ]
+					);
+				}
+
+				if ( '' === attr.get('value') && attr.get('default_value') ) {
+					attr.set(
+						'value',
+						attr.get('default_value')
 					);
 				}
 			}

--- a/js-tests/src/shortcodeAttributeModelSpec.js
+++ b/js-tests/src/shortcodeAttributeModelSpec.js
@@ -3,20 +3,39 @@ var ShortcodeAttribute = require('../../js/src/models/shortcode-attribute');
 describe( "Shortcode Attribute Model", function() {
 
 	var attrData = {
-		attr:        'attr',
-		label:       'Attribute',
-		type:        'text',
-		value:       'test value',
-		description: 'test description',
+		attr:           'attr',
+		label:          'Attribute',
+		type:           'text',
+		value:          'test value',
+		description:    'test description',
 		meta:  {
 			placeholder: 'test placeholder'
 		}
-	};
+	},
+	expectedAttrData = _.extend( attrData, { default_value: '' });
 
 	var attr = new ShortcodeAttribute( attrData );
 
 	it( 'should correctly set data.', function() {
-		expect( attr.toJSON() ).toEqual( attrData );
+		expect( attr.toJSON() ).toEqual( expectedAttrData );
+	});
+
+	var attrData = {
+		attr:           'attr',
+		label:          'Attribute',
+		type:           'text',
+		default_value:  'test value',
+		description:    'test description',
+		meta:  {
+			placeholder: 'test placeholder'
+		}
+	},
+	expectedAttrData = _.extend( attrData, { value: 'test_value' });
+
+	var attr = new ShortcodeAttribute( attrData );
+
+	it( 'should correctly apply default values to shortcode attributes.', function() {
+		expect( attr.toJSON() ).toEqual( expectedAttrData );
 	});
 
 

--- a/js/build/field-attachment.js
+++ b/js/build/field-attachment.js
@@ -209,11 +209,12 @@ var Backbone = (typeof window !== "undefined" ? window.Backbone : typeof global 
 
 var ShortcodeAttribute = Backbone.Model.extend({
 	defaults: {
-		attr:        '',
-		label:       '',
-		type:        '',
-		value:       '',
-		description: '',
+		attr:          '',
+		label:         '',
+		type:          '',
+		value:         '',
+		default_value: '',
+		description:   '',
 		meta: {
 			placeholder: '',
 		}
@@ -369,6 +370,11 @@ var editAttributeField = Backbone.View.extend( {
 		if ( data.placeholder ) {
 			data.meta.placeholder = data.placeholder;
 			delete data.placeholder;
+		}
+
+		// Apply default value if one exists and no value is set yet
+		if ( '' === data.value && data.default_value.length > 0 ) {
+			data.value = data.default_value;
 		}
 
 		// Convert meta JSON to attribute string.

--- a/js/build/field-color.js
+++ b/js/build/field-color.js
@@ -80,11 +80,12 @@ var Backbone = (typeof window !== "undefined" ? window.Backbone : typeof global 
 
 var ShortcodeAttribute = Backbone.Model.extend({
 	defaults: {
-		attr:        '',
-		label:       '',
-		type:        '',
-		value:       '',
-		description: '',
+		attr:          '',
+		label:         '',
+		type:          '',
+		value:         '',
+		default_value: '',
+		description:   '',
 		meta: {
 			placeholder: '',
 		}
@@ -240,6 +241,11 @@ var editAttributeField = Backbone.View.extend( {
 		if ( data.placeholder ) {
 			data.meta.placeholder = data.placeholder;
 			delete data.placeholder;
+		}
+
+		// Apply default value if one exists and no value is set yet
+		if ( '' === data.value && data.default_value.length > 0 ) {
+			data.value = data.default_value;
 		}
 
 		// Convert meta JSON to attribute string.

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -113,11 +113,12 @@ var Backbone = (typeof window !== "undefined" ? window.Backbone : typeof global 
 
 var ShortcodeAttribute = Backbone.Model.extend({
 	defaults: {
-		attr:        '',
-		label:       '',
-		type:        '',
-		value:       '',
-		description: '',
+		attr:          '',
+		label:         '',
+		type:          '',
+		value:         '',
+		default_value: '',
+		description:   '',
 		meta: {
 			placeholder: '',
 		}
@@ -299,6 +300,13 @@ var shortcodeViewConstructor = {
 					attr.set(
 						'value',
 						options.attrs.named[ attr.get('attr') ]
+					);
+				}
+
+				if ( '' === attr.get('value') && attr.get('default_value') ) {
+					attr.set(
+						'value',
+						attr.get('default_value')
 					);
 				}
 			}
@@ -617,6 +625,11 @@ var editAttributeField = Backbone.View.extend( {
 		if ( data.placeholder ) {
 			data.meta.placeholder = data.placeholder;
 			delete data.placeholder;
+		}
+
+		// Apply default value if one exists and no value is set yet
+		if ( '' === data.value && data.default_value.length > 0 ) {
+			data.value = data.default_value;
 		}
 
 		// Convert meta JSON to attribute string.

--- a/js/src/models/shortcode-attribute.js
+++ b/js/src/models/shortcode-attribute.js
@@ -2,11 +2,12 @@ var Backbone = require('backbone');
 
 var ShortcodeAttribute = Backbone.Model.extend({
 	defaults: {
-		attr:        '',
-		label:       '',
-		type:        '',
-		value:       '',
-		description: '',
+		attr:          '',
+		label:         '',
+		type:          '',
+		value:         '',
+		default_value: '',
+		description:   '',
 		meta: {
 			placeholder: '',
 		}

--- a/js/src/utils/shortcode-view-constructor.js
+++ b/js/src/utils/shortcode-view-constructor.js
@@ -37,6 +37,13 @@ var shortcodeViewConstructor = {
 						options.attrs.named[ attr.get('attr') ]
 					);
 				}
+
+				if ( '' === attr.get('value') && attr.get('default_value') ) {
+					attr.set(
+						'value',
+						attr.get('default_value')
+					);
+				}
 			}
 		);
 

--- a/js/src/views/edit-attribute-field.js
+++ b/js/src/views/edit-attribute-field.js
@@ -31,6 +31,11 @@ var editAttributeField = Backbone.View.extend( {
 			delete data.placeholder;
 		}
 
+		// Apply default value if one exists and no value is set yet
+		if ( '' === data.value && data.default_value.length > 0 ) {
+			data.value = data.default_value;
+		}
+
 		// Convert meta JSON to attribute string.
 		var _meta = [];
 		for ( var key in data.meta ) {


### PR DESCRIPTION
Adds an additional field to shortcode attribute data model called 'default_value'. If a default_value is set and the value is empty, the value will be set to the default value.

Can I get a review of this? @jitendraharpalani58 @noppanit @danielbachhuber 
This attribute would be useful to me for https://github.com/fusioneng/image-shortcake and I'd like to have it added here if possible. This is the first time I've looked at Shortcake internals and I don't know if this is the best way to do this, though...
