### PR TITLE
Force mce view sandbox to clear floated elements inside it

### DIFF
--- a/css/sass/shortcode-ui-editor-styles.scss
+++ b/css/sass/shortcode-ui-editor-styles.scss
@@ -16,5 +16,10 @@
 		color: #666;
 		font-size: 14px;
 	}
+}
 
+body#wpview-iframe-sandbox {
+	display: inline-block;
+	width: 100%;
+	overflow: hidden;
 }

--- a/css/shortcode-ui-editor-styles.css
+++ b/css/shortcode-ui-editor-styles.css
@@ -8,4 +8,9 @@
   color: #666;
   font-size: 14px; }
 
+body#wpview-iframe-sandbox {
+  display: inline-block;
+  width: 100%;
+  overflow: hidden; }
+
 /*# sourceMappingURL=shortcode-ui-editor-styles.css.map */

--- a/css/shortcode-ui-editor-styles.css.map
+++ b/css/shortcode-ui-editor-styles.css.map
@@ -5,6 +5,6 @@
 		"../shortcode-ui-editor-styles.scss"
 	],
 	"sourcesContent": [],
-	"mappings": "AAGA,AAAY,AAA0B;EACnC,AAAS;AAIZ,AAAa;EACX,AAAO;EACP,AAAa;AAGf,AAAa;EACX,AAAa;EACb,AAAO;EACP,AAAW",
+	"mappings": "AAGA,AAAY,AAA0B;EACnC,AAAS;AAIZ,AAAa;EACX,AAAO;EACP,AAAa;AAGf,AAAa;EACX,AAAa;EACb,AAAO;EACP,AAAW;;AAIb,AAAI;EACH,AAAS;EACT,AAAO;EACP,AAAU",
 	"names": []
 }


### PR DESCRIPTION
Shortcodes that contain floated elements break in preview because the iframe body collapses to zero height, leaving the floated element invisible.

This avoids that problem by using the `display: inline-block` / `overflow: hidden` on the body of the wpview iframe.

Addresses the problem discussed in #9. 
