### PR TITLE
Allow HTML in attributes

### DIFF
--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -50,6 +50,21 @@ class Shortcode_UI {
 		$args['shortcode_tag'] = $shortcode_tag;
 		$this->shortcodes[ $shortcode_tag ] = $args;
 
+		// filter the attrs to decode fields with escape=true
+		add_filter( "shortcode_atts_{$shortcode_tag}", function( $out, $pairs, $atts ) use ( $args ) {
+
+			$fields = Shortcode_UI_Fields::get_instance()->get_fields();
+
+			foreach( $args['attrs'] as $attr ) {
+				if ( ! $fields[ $attr['type'] ]['escape'] ) {
+					continue;
+				}
+				$out[ $attr['attr'] ] = rawurldecode( $out[ $attr['attr'] ] );
+			}
+
+			return $out;
+		}, 1, 3 );
+
 	}
 
 	public function get_shortcodes() {

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -55,7 +55,7 @@ class Shortcode_UI {
 
 			$fields = Shortcode_UI_Fields::get_instance()->get_fields();
 
-			foreach( $args['attrs'] as $attr ) {
+			foreach ( $args['attrs'] as $attr ) {
 				if ( ! $fields[ $attr['type'] ]['escape'] ) {
 					continue;
 				}

--- a/inc/fields/class-shortcode-ui-fields.php
+++ b/inc/fields/class-shortcode-ui-fields.php
@@ -8,6 +8,7 @@ class Shortcode_UI_Fields {
 	private $field_defaults = array(
 		'template' => 'shortcode-ui-field-text',
 		'view'     => 'editAttributeField',
+		'escape'   => false,
 	);
 
 	// Field Settings.
@@ -15,6 +16,7 @@ class Shortcode_UI_Fields {
 		'text' => array(),
 		'textarea' => array(
 			'template' => 'shortcode-ui-field-textarea',
+			'escape'   => true
 		),
 		'url' => array(
 			'template' => 'shortcode-ui-field-url',

--- a/inc/fields/class-shortcode-ui-fields.php
+++ b/inc/fields/class-shortcode-ui-fields.php
@@ -16,7 +16,7 @@ class Shortcode_UI_Fields {
 		'text' => array(),
 		'textarea' => array(
 			'template' => 'shortcode-ui-field-textarea',
-			'escape'   => true
+			'escape'   => true,
 		),
 		'url' => array(
 			'template' => 'shortcode-ui-field-url',

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -38,6 +38,7 @@ describe( "Shortcode Attribute Model", function() {
 		type:        'text',
 		value:       'test value',
 		description: 'test description',
+		escape:      false,
 		meta:  {
 			placeholder: 'test placeholder'
 		}
@@ -73,7 +74,7 @@ describe( "Shortcode Model", function() {
 				label:       'Attribute',
 				type:        'text',
 				value:       'test value',
-				placeholder: 'test placeholder',
+				placeholder: 'test placeholder'
 			}
 		],
 		inner_content: {
@@ -359,6 +360,7 @@ var ShortcodeAttribute = Backbone.Model.extend({
 		type:        '',
 		value:       '',
 		description: '',
+		escape:      false,
 		meta: {
 			placeholder: '',
 		}
@@ -441,6 +443,13 @@ Shortcode = Backbone.Model.extend({
 			// Skip empty attributes.
 			if ( ! attr.get( 'value' ) ||  attr.get( 'value' ).length < 1 ) {
 				return;
+			}
+
+			var type = attr.get( 'type' );
+
+			// Encode textareas incase HTML
+			if ( shortcodeUIFieldData[ type ] && shortcodeUIFieldData[ type ].escape  ) {
+				attr.set( 'value', encodeURIComponent( decodeURIComponent( attr.get( 'value' ) ) ) );
 			}
 
 			attrs.push( attr.get( 'attr' ) + '="' + attr.get( 'value' ) + '"' );

--- a/js-tests/src/shortcodeAttributeModelSpec.js
+++ b/js-tests/src/shortcodeAttributeModelSpec.js
@@ -8,6 +8,7 @@ describe( "Shortcode Attribute Model", function() {
 		type:        'text',
 		value:       'test value',
 		description: 'test description',
+		escape:      false,
 		meta:  {
 			placeholder: 'test placeholder'
 		}

--- a/js-tests/src/shortcodeModelSpec.js
+++ b/js-tests/src/shortcodeModelSpec.js
@@ -17,7 +17,7 @@ describe( "Shortcode Model", function() {
 				label:       'Attribute',
 				type:        'text',
 				value:       'test value',
-				placeholder: 'test placeholder',
+				placeholder: 'test placeholder'
 			}
 		],
 		inner_content: {

--- a/js/build/field-attachment.js
+++ b/js/build/field-attachment.js
@@ -214,6 +214,7 @@ var ShortcodeAttribute = Backbone.Model.extend({
 		type:        '',
 		value:       '',
 		description: '',
+		escape:      false,
 		meta: {
 			placeholder: '',
 		}
@@ -296,6 +297,13 @@ Shortcode = Backbone.Model.extend({
 			// Skip empty attributes.
 			if ( ! attr.get( 'value' ) ||  attr.get( 'value' ).length < 1 ) {
 				return;
+			}
+
+			var type = attr.get( 'type' );
+
+			// Encode textareas incase HTML
+			if ( shortcodeUIFieldData[ type ] && shortcodeUIFieldData[ type ].escape  ) {
+				attr.set( 'value', encodeURIComponent( decodeURIComponent( attr.get( 'value' ) ) ) );
 			}
 
 			attrs.push( attr.get( 'attr' ) + '="' + attr.get( 'value' ) + '"' );

--- a/js/build/field-color.js
+++ b/js/build/field-color.js
@@ -85,6 +85,7 @@ var ShortcodeAttribute = Backbone.Model.extend({
 		type:        '',
 		value:       '',
 		description: '',
+		escape:      false,
 		meta: {
 			placeholder: '',
 		}
@@ -167,6 +168,13 @@ Shortcode = Backbone.Model.extend({
 			// Skip empty attributes.
 			if ( ! attr.get( 'value' ) ||  attr.get( 'value' ).length < 1 ) {
 				return;
+			}
+
+			var type = attr.get( 'type' );
+
+			// Encode textareas incase HTML
+			if ( shortcodeUIFieldData[ type ] && shortcodeUIFieldData[ type ].escape  ) {
+				attr.set( 'value', encodeURIComponent( decodeURIComponent( attr.get( 'value' ) ) ) );
 			}
 
 			attrs.push( attr.get( 'attr' ) + '="' + attr.get( 'value' ) + '"' );

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -118,6 +118,7 @@ var ShortcodeAttribute = Backbone.Model.extend({
 		type:        '',
 		value:       '',
 		description: '',
+		escape:      false,
 		meta: {
 			placeholder: '',
 		}
@@ -200,6 +201,13 @@ Shortcode = Backbone.Model.extend({
 			// Skip empty attributes.
 			if ( ! attr.get( 'value' ) ||  attr.get( 'value' ).length < 1 ) {
 				return;
+			}
+
+			var type = attr.get( 'type' );
+
+			// Encode textareas incase HTML
+			if ( shortcodeUIFieldData[ type ] && shortcodeUIFieldData[ type ].escape  ) {
+				attr.set( 'value', encodeURIComponent( decodeURIComponent( attr.get( 'value' ) ) ) );
 			}
 
 			attrs.push( attr.get( 'attr' ) + '="' + attr.get( 'value' ) + '"' );
@@ -715,15 +723,13 @@ var EditShortcodeForm = wp.Backbone.View.extend({
 				return;
 			}
 
-			var templateData = {
-				value: attr.get('value'),
-				attr_raw: {
-					name: attr.get('value')
-				}
-			}
-
 			var viewObjName = shortcodeUIFieldData[ type ].view;
 			var tmplName    = shortcodeUIFieldData[ type ].template;
+
+			// decode textareas / html
+			if ( shortcodeUIFieldData[ type ].escape ) {
+				attr.set( 'value', decodeURIComponent( attr.get( 'value' ) ) );
+			}
 
 			var view       = new sui.views[viewObjName]( { model: attr } );
 			view.template  = wp.media.template( tmplName );

--- a/js/src/models/shortcode-attribute.js
+++ b/js/src/models/shortcode-attribute.js
@@ -7,6 +7,7 @@ var ShortcodeAttribute = Backbone.Model.extend({
 		type:        '',
 		value:       '',
 		description: '',
+		escape:      false,
 		meta: {
 			placeholder: '',
 		}

--- a/js/src/models/shortcode.js
+++ b/js/src/models/shortcode.js
@@ -71,6 +71,13 @@ Shortcode = Backbone.Model.extend({
 				return;
 			}
 
+			var type = attr.get( 'type' );
+
+			// Encode textareas incase HTML
+			if ( shortcodeUIFieldData[ type ] && shortcodeUIFieldData[ type ].escape  ) {
+				attr.set( 'value', encodeURIComponent( decodeURIComponent( attr.get( 'value' ) ) ) );
+			}
+
 			attrs.push( attr.get( 'attr' ) + '="' + attr.get( 'value' ) + '"' );
 
 		} );

--- a/js/src/views/edit-shortcode-form.js
+++ b/js/src/views/edit-shortcode-form.js
@@ -36,15 +36,13 @@ var EditShortcodeForm = wp.Backbone.View.extend({
 				return;
 			}
 
-			var templateData = {
-				value: attr.get('value'),
-				attr_raw: {
-					name: attr.get('value')
-				}
-			}
-
 			var viewObjName = shortcodeUIFieldData[ type ].view;
 			var tmplName    = shortcodeUIFieldData[ type ].template;
+
+			// decode textareas / html
+			if ( shortcodeUIFieldData[ type ].escape ) {
+				attr.set( 'value', decodeURIComponent( attr.get( 'value' ) ) );
+			}
 
 			var view       = new sui.views[viewObjName]( { model: attr } );
 			view.template  = wp.media.template( tmplName );


### PR DESCRIPTION
This PR adds support for escaping html in attributes so that HTML no longer breaks the view rendering.

It should also go some way to paving the way forward for https://github.com/fusioneng/Shortcake/issues/236

It does a few things:
1. Adds a default attribute for field types called 'escape'
2. If 'escape' is true the value is passed through `encodeURIComponent()` and `decodeURIComponent()` where appropriate
3. Shortcodes with fields that are marked to be escaped have a filter added to run `rawurldecode()` automatically on the values provided the shortcode author uses the `shortcode_atts()` function and provides the 3rd parameter stating the shortcode tag name

Example:

``` php
<?php

add_shortcode( 'html_textarea_field', function ( $attr = '', $content = false ) {

    $attr = shortcode_atts( array(
       'html_content'   => '',
    ), $attr, 'html_textarea_field' ); // 3rd param here enables the automatic rawurldecode() filter

    $output = apply_filters( 'the_content', $attr['html_content'] );

    return $output;
} );

if ( function_exists( 'shortcode_ui_register_for_shortcode' ) ) {

    shortcode_ui_register_for_shortcode( 'html_textarea_field', array(
        'label'         => __( 'HTML Textarea' ),
        'listItemImage' => 'dashicons-align-left',
        'attrs'         => array(
            array(
                 'label' => __( 'HTML' ),
                 'attr'  => 'html_content',
                 'type'  => 'textarea',
            )
        )
     );

}
```
