### PR TITLE
Use the smallest size available for preview if no "thumbnail" attachment size exists

### DIFF
--- a/js/build/field-attachment.js
+++ b/js/build/field-attachment.js
@@ -124,10 +124,14 @@ sui.views.editAttributeFieldAttachment = editAttributeField.extend( {
 
 			} else {
 
+				attachmentThumb = (typeof attachment.sizes.thumbnail !== 'undefined') ?
+					attachment.sizes.thumbnail :
+					_.min( attachment.sizes, function( size ) { return size.width } );
+
 				$( '<img/>', {
-					src:    attachment.sizes.thumbnail.url,
-					width:  attachment.sizes.thumbnail.width,
-					height: attachment.sizes.thumbnail.height,
+					src:    attachmentThumb.url,
+					width:  attachmentThumb.width,
+					height: attachmentThumb.height,
 					alt:    attachment.alt,
 				} ) .appendTo( $thumbnail )
 

--- a/js/build/field-attachment.js
+++ b/js/build/field-attachment.js
@@ -126,7 +126,7 @@ sui.views.editAttributeFieldAttachment = editAttributeField.extend( {
 
 				attachmentThumb = (typeof attachment.sizes.thumbnail !== 'undefined') ?
 					attachment.sizes.thumbnail :
-					_.min( attachment.sizes, function( size ) { return size.width } );
+					_.first( _.sortBy( attachment.sizes, 'width' ) );
 
 				$( '<img/>', {
 					src:    attachmentThumb.url,

--- a/js/src/field-attachment.js
+++ b/js/src/field-attachment.js
@@ -90,7 +90,7 @@ sui.views.editAttributeFieldAttachment = editAttributeField.extend( {
 
 				attachmentThumb = (typeof attachment.sizes.thumbnail !== 'undefined') ?
 					attachment.sizes.thumbnail :
-					_.min( attachment.sizes, function( size ) { return size.width } );
+					_.first( _.sortBy( attachment.sizes, 'width' ) );
 
 				$( '<img/>', {
 					src:    attachmentThumb.url,

--- a/js/src/field-attachment.js
+++ b/js/src/field-attachment.js
@@ -88,10 +88,14 @@ sui.views.editAttributeFieldAttachment = editAttributeField.extend( {
 
 			} else {
 
+				attachmentThumb = (typeof attachment.sizes.thumbnail !== 'undefined') ?
+					attachment.sizes.thumbnail :
+					_.min( attachment.sizes, function( size ) { return size.width } );
+
 				$( '<img/>', {
-					src:    attachment.sizes.thumbnail.url,
-					width:  attachment.sizes.thumbnail.width,
-					height: attachment.sizes.thumbnail.height,
+					src:    attachmentThumb.url,
+					width:  attachmentThumb.width,
+					height: attachmentThumb.height,
 					alt:    attachment.alt,
 				} ) .appendTo( $thumbnail )
 


### PR DESCRIPTION
Fixes #318.

Trying to access the thumbnail size when no thumbnail exists causes
console errors and a failure to display attachment preview. This falls
back on using the smallest (by width) attachment size available if there
isn't a "thumbnail" size defined for an attachment.
