### PR TITLE
Require select elements to have a value set

### DIFF
--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -47,6 +47,13 @@ class Shortcode_UI {
 			$args['attrs'] = array();
 		}
 
+		foreach ( $args['attrs'] as &$attr ) {
+			if ( 'select' === $attr['type'] && ! isset( $attr['value'] ) ) {
+				$_shortcodes = array_keys( $attr['options'] );
+				$attr['value'] = array_shift( $_shortcodes );
+			}
+		}
+
 		$args['shortcode_tag'] = $shortcode_tag;
 		$this->shortcodes[ $shortcode_tag ] = $args;
 
@@ -88,6 +95,7 @@ class Shortcode_UI {
 				if ( ! empty( $args['post_type'] ) && ! in_array( $screen->post_type, $args['post_type'] ) ) {
 					unset( $shortcodes[ $key ] );
 				}
+
 			}
 		}
 

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -95,7 +95,6 @@ class Shortcode_UI {
 				if ( ! empty( $args['post_type'] ) && ! in_array( $screen->post_type, $args['post_type'] ) ) {
 					unset( $shortcodes[ $key ] );
 				}
-
 			}
 		}
 


### PR DESCRIPTION
On registering UI for a shortcode, checks that any attributes of type "select" have a value set. 

If not, sets their value to the key of the first option, as this is the behavior that will be expected by the user who sees that the first element in the select list appears to be selected on the form.

See #323.
