### PR TITLE
Use "regular-text" class for inputs in WordPress admin

### DIFF
--- a/inc/templates/edit-form.tpl.php
+++ b/inc/templates/edit-form.tpl.php
@@ -18,7 +18,7 @@
 <script type="text/html" id="tmpl-shortcode-ui-field-text">
 	<div class="field-block">
 		<label for="{{ data.id }}">{{ data.label }}</label>
-		<input type="text" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value }}" {{{ data.meta }}}/>
+		<input type="text" class="regular-text" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value }}" {{{ data.meta }}}/>
 		<# if ( typeof data.description == 'string' ) { #>
 			<p class="description">{{ data.description }}</p>
 		<# } #>
@@ -89,7 +89,7 @@
 <script type="text/html" id="tmpl-shortcode-ui-field-email">
 	<div class="field-block">
 		<label for="{{ data.id }}">{{ data.label }}</label>
-		<input type="email" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value}}" {{{ data.meta }}}/>
+		<input type="email" class="regular-text" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value}}" {{{ data.meta }}}/>
 		<# if ( typeof data.description == 'string' ) { #>
 			<p class="description">{{ data.description }}</p>
 		<# } #>
@@ -99,7 +99,7 @@
 <script type="text/html" id="tmpl-shortcode-ui-field-number">
 	<div class="field-block">
 		<label for="{{ data.id }}">{{ data.label }}</label>
-		<input type="number" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value}}" {{{ data.meta }}}/>
+		<input type="number" class="regular-text" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value}}" {{{ data.meta }}}/>
 		<# if ( typeof data.description == 'string' ) { #>
 			<p class="description">{{ data.description }}</p>
 		<# } #>


### PR DESCRIPTION
WordPress has some distinctive admin styles for form elements. Applying the base classes which WP uses to mark up form elements will make the shortcode UI form look less incongruous with the rest of the admin area. It's also easier to enter text with a wider input (`regular-text` is 25em wide; browser defaults for input width vary, but can be as low as 150px on Firefox)

_Text boxes, before:_

![screen shot 2015-05-19 at 4 05 43 pm](https://cloud.githubusercontent.com/assets/665992/7715847/ed35085a-fe40-11e4-8d6a-d537754b4769.png)

_After:_

![screen shot 2015-05-19 at 4 07 48 pm](https://cloud.githubusercontent.com/assets/665992/7715850/fcaf100a-fe40-11e4-91a1-bc98f0e49dc3.png)
