### PR TITLE
Only enqueue scripts in the admin area

### DIFF
--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -73,6 +73,10 @@ class Shortcode_UI {
 
 	public function enqueue() {
 
+		if ( ! is_admin() ) {
+			return;
+		}
+
 		if ( did_action( 'enqueue_shortcode_ui' ) ) {
 			return;
 		}


### PR DESCRIPTION
Quick fix for #337.

Because `get_current_screen()` breaks if not in admin. Also, since shortcodes are tied to post types, it doesn't currently make sense to load shortcode UI on the frontend, such as comments area.
