### PR TITLE
Make sure shortcode prop is set

### DIFF
--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -727,12 +727,11 @@ var EditShortcodeForm = wp.Backbone.View.extend({
 		if ( innerContent && typeof innerContent.attributes.type !== 'undefined' ) {
 
 			// add UI for inner_content
-			var view = new editAttributeField( {
-				model:     innerContent,
-				shortcode: t.model,
-			} );
+			var view = new editAttributeField( { model: innerContent } );
 
-			view.template = wp.media.template( 'shortcode-ui-content' );
+			view.shortcode = t.model;
+			view.template  = wp.media.template( 'shortcode-ui-content' );
+
 			t.views.add( '.edit-shortcode-form-fields', view );
 
 		}

--- a/js/src/views/edit-shortcode-form.js
+++ b/js/src/views/edit-shortcode-form.js
@@ -17,12 +17,11 @@ var EditShortcodeForm = wp.Backbone.View.extend({
 		if ( innerContent && typeof innerContent.attributes.type !== 'undefined' ) {
 
 			// add UI for inner_content
-			var view = new editAttributeField( {
-				model:     innerContent,
-				shortcode: t.model,
-			} );
+			var view = new editAttributeField( { model: innerContent } );
 
-			view.template = wp.media.template( 'shortcode-ui-content' );
+			view.shortcode = t.model;
+			view.template  = wp.media.template( 'shortcode-ui-content' );
+
 			t.views.add( '.edit-shortcode-form-fields', view );
 
 		}


### PR DESCRIPTION
Bug introduced here: https://github.com/fusioneng/Shortcake/commit/c575c6527165c88ffbb9c77edb552c3ef295a012

Problem - the `shortcode` property on the view was not getting set correctly. Caused the following error when trying to edit a shortcode.

`Uncaught TypeError: Cannot read property 'attributes' of undefined`

Why? In recent versions of Backbone - you cannot pass arbitrary properties to a view.  This wasn't an issue before - because we just weren't using it.

This problem only affects the `inner_content` field - because for all other fields, we set the shortcode property after instantiating - which works OK.

The fix - set properties in the same way for `inner_content` field view that they are for all other fields to ensure it is actually set.
