### PR TITLE
Only call `get_current_screen()` when the function exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ We've removed the compatibility shim for the magical `content` attribute. If you
 * Added Chinese translation.
 * Added French translation.
 * Added Spanish translation.
+* Bug fix: Prevent fataling when editor is loaded in the frontend context.
 * Bug fix: Color field should also support `meta` argument.
 
 ### 0.3 (April 27, 2015) ###

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -82,7 +82,7 @@ class Shortcode_UI {
 		wp_enqueue_media();
 
 		$shortcodes = array_values( $this->get_shortcodes() );
-		$screen = get_current_screen();
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : false;
 		if ( $screen && ! empty( $screen->post_type ) ) {
 			foreach ( $shortcodes as $key => $args ) {
 				if ( ! empty( $args['post_type'] ) && ! in_array( $screen->post_type, $args['post_type'] ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -45,6 +45,7 @@ We've removed the compatibility shim for the magical `content` attribute. If you
 * Added Chinese translation.
 * Added French translation.
 * Added Spanish translation.
+* Bug fix: Prevent fataling when editor is loaded in the frontend context.
 * Bug fix: Color field should also support `meta` argument.
 
 = 0.3 (April 27, 2015) =


### PR DESCRIPTION
`get_current_screen()` only exists in admin context. While Shortcode UI isn't full supported on the frontend, not fataling is the least we can do

Fixes #337
