### PR TITLE
Remove trailing whitespace from shortcodes without attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ We've removed the compatibility shim for the magical `content` attribute. If you
 * Added French translation.
 * Added Spanish translation.
 * Bug fix: Color field should also support `meta` argument.
+* Bug fix: Remove trailing whitespace from shortcodes without attributes.
 
 ### 0.3 (April 27, 2015) ###
 * **Breaking change**: We've removed the compatibility shim for the magical `content` attribute. If you were using this to support editing inner content, you'll need to change your UI registration to use `inner_content`.

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -120,6 +120,10 @@ describe( "Shortcode Model", function() {
 		_shortcode.get('inner_content').unset( 'value' );
 		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode attr="test value"]' );
 
+		// Test without attributes
+		_shortcode.get( 'attrs' ).first().unset( 'value' );
+		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode]' );
+
 	});
 
 });

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -461,7 +461,11 @@ Shortcode = Backbone.Model.extend({
 			content = this.get( 'inner_content' ).get( 'value' );
 		}
 
-		template = "[{{ shortcode }} {{ attributes }}]"
+		if ( attrs.length > 0 ) {
+			template = "[{{ shortcode }} {{ attributes }}]"
+		} else {
+			template = "[{{ shortcode }}]"
+		}
 
 		if ( content && content.length > 0 ) {
 			template += "{{ content }}[/{{ shortcode }}]"

--- a/js-tests/src/shortcodeModelSpec.js
+++ b/js-tests/src/shortcodeModelSpec.js
@@ -64,6 +64,10 @@ describe( "Shortcode Model", function() {
 		_shortcode.get('inner_content').unset( 'value' );
 		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode attr="test value"]' );
 
+		// Test without attributes
+		_shortcode.get( 'attrs' ).first().unset( 'value' );
+		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode]' );
+
 	});
 
 });

--- a/js/build/field-attachment.js
+++ b/js/build/field-attachment.js
@@ -310,7 +310,11 @@ Shortcode = Backbone.Model.extend({
 			content = this.get( 'inner_content' ).get( 'value' );
 		}
 
-		template = "[{{ shortcode }} {{ attributes }}]"
+		if ( attrs.length > 0 ) {
+			template = "[{{ shortcode }} {{ attributes }}]"
+		} else {
+			template = "[{{ shortcode }}]"
+		}
 
 		if ( content && content.length > 0 ) {
 			template += "{{ content }}[/{{ shortcode }}]"

--- a/js/build/field-color.js
+++ b/js/build/field-color.js
@@ -177,7 +177,11 @@ Shortcode = Backbone.Model.extend({
 			content = this.get( 'inner_content' ).get( 'value' );
 		}
 
-		template = "[{{ shortcode }} {{ attributes }}]"
+		if ( attrs.length > 0 ) {
+			template = "[{{ shortcode }} {{ attributes }}]"
+		} else {
+			template = "[{{ shortcode }}]"
+		}
 
 		if ( content && content.length > 0 ) {
 			template += "{{ content }}[/{{ shortcode }}]"

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -210,7 +210,11 @@ Shortcode = Backbone.Model.extend({
 			content = this.get( 'inner_content' ).get( 'value' );
 		}
 
-		template = "[{{ shortcode }} {{ attributes }}]"
+		if ( attrs.length > 0 ) {
+			template = "[{{ shortcode }} {{ attributes }}]"
+		} else {
+			template = "[{{ shortcode }}]"
+		}
 
 		if ( content && content.length > 0 ) {
 			template += "{{ content }}[/{{ shortcode }}]"

--- a/js/src/models/shortcode.js
+++ b/js/src/models/shortcode.js
@@ -79,7 +79,11 @@ Shortcode = Backbone.Model.extend({
 			content = this.get( 'inner_content' ).get( 'value' );
 		}
 
-		template = "[{{ shortcode }} {{ attributes }}]"
+		if ( attrs.length > 0 ) {
+			template = "[{{ shortcode }} {{ attributes }}]"
+		} else {
+			template = "[{{ shortcode }}]"
+		}
 
 		if ( content && content.length > 0 ) {
 			template += "{{ content }}[/{{ shortcode }}]"

--- a/readme.txt
+++ b/readme.txt
@@ -46,6 +46,7 @@ We've removed the compatibility shim for the magical `content` attribute. If you
 * Added French translation.
 * Added Spanish translation.
 * Bug fix: Color field should also support `meta` argument.
+* Bug fix: Remove trailing whitespace from shortcodes without attributes.
 
 = 0.3 (April 27, 2015) =
 * **Breaking change**: We've removed the compatibility shim for the magical `content` attribute. If you were using this to support editing inner content, you'll need to change your UI registration to use `inner_content`.


### PR DESCRIPTION
Fixes #334
