### PR TITLE
Get value of named attributes correctly.

### DIFF
--- a/js/build/field-color.js
+++ b/js/build/field-color.js
@@ -276,7 +276,7 @@ var editAttributeField = Backbone.View.extend( {
 	 */
 	inputChanged: function( e ) {
 
-		if ( this.getValue( 'attr' ) ) {
+		if ( this.model.get( 'attr' ) ) {
 			var $el = this.$el.find( '[name="' + this.model.get( 'attr' ) + '"]' );
 		} else {
 			var $el = this.$el.find( '[name="inner_content"]' );

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -1060,7 +1060,7 @@ var editAttributeField = Backbone.View.extend( {
 	 */
 	inputChanged: function( e ) {
 
-		if ( this.getValue( 'attr' ) ) {
+		if ( this.model.get( 'attr' ) ) {
 			var $el = this.$el.find( '[name="' + this.model.get( 'attr' ) + '"]' );
 		} else {
 			var $el = this.$el.find( '[name="inner_content"]' );

--- a/js/src/views/edit-attribute-field.js
+++ b/js/src/views/edit-attribute-field.js
@@ -61,7 +61,7 @@ var editAttributeField = Backbone.View.extend( {
 	 */
 	inputChanged: function( e ) {
 
-		if ( this.getValue( 'attr' ) ) {
+		if ( this.model.get( 'attr' ) ) {
 			var $el = this.$el.find( '[name="' + this.model.get( 'attr' ) + '"]' );
 		} else {
 			var $el = this.$el.find( '[name="inner_content"]' );


### PR DESCRIPTION
This was broken in 855d9a8, when I added some sugar functions
for accessing values of fields. `getValue()` should only be used to get
a field's user-set value, not for accessing other data such as attribute
name.

Related issue: https://github.com/fusioneng/fusion-theme/issues/3423
