### PR TITLE
Fix undefined function JS error

### DIFF
--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -630,7 +630,7 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 		var self = this;
 
 		if ( editAttributeFieldAttachment.getFromCache( id ) ) {
-			self._renderPreview( this._getFromCache( id ) );
+			self._renderPreview( editAttributeFieldAttachment.getFromCache( id ) );
 			return;
 
 			// Call the updateValue() function, to trigger any listeners

--- a/js/src/views/edit-attribute-field-attachment.js
+++ b/js/src/views/edit-attribute-field-attachment.js
@@ -26,7 +26,7 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 		var self = this;
 
 		if ( editAttributeFieldAttachment.getFromCache( id ) ) {
-			self._renderPreview( this._getFromCache( id ) );
+			self._renderPreview( editAttributeFieldAttachment.getFromCache( id ) );
 			return;
 
 			// Call the updateValue() function, to trigger any listeners


### PR DESCRIPTION
I get a JS error when using the attachment field in the lates Shortcake. 

Looks like this didn't get updated following https://github.com/fusioneng/Shortcake/commit/d631032f387702c77d8df930a59f9799137b5be9
