### PR TITLE
Update range output on `input` event

### DIFF
--- a/js/build/field-color.js
+++ b/js/build/field-color.js
@@ -232,6 +232,8 @@ var editAttributeField = Backbone.View.extend( {
 		'change input[type=date]':     'inputChanged',
 		'change input[type=url]':      'inputChanged',
 		'change input[type=range]':    'inputChanged',
+
+		'input input[type=range]':     'updateRangeOutput',
 	},
 
 	render: function() {
@@ -287,16 +289,16 @@ var editAttributeField = Backbone.View.extend( {
 			this.setValue( $el.filter(':checked').first().val() );
 		} else if ( 'checkbox' === this.model.attributes.type ) {
 			this.setValue( $el.is( ':checked' ) );
-		}  else if ( 'range' === this.model.attributes.type ) {
-			var rangeId =  '#' + e.target.id + '_indicator';
-			var rangeValue = e.target.value;
-			document.querySelector( rangeId ).value = rangeValue;
-			this.setValue( $el.val() );
 		} else {
 			this.setValue( $el.val() );
 		}
 
 		this.triggerCallbacks();
+	},
+
+	updateRangeOutput: function( e ) {
+		var range = e.target;
+		document.getElementById( range.id + '_indicator' ).value = range.value;
 	},
 
 	getValue: function() {

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -1016,6 +1016,8 @@ var editAttributeField = Backbone.View.extend( {
 		'change input[type=date]':     'inputChanged',
 		'change input[type=url]':      'inputChanged',
 		'change input[type=range]':    'inputChanged',
+
+		'input input[type=range]':     'updateRangeOutput',
 	},
 
 	render: function() {
@@ -1071,16 +1073,16 @@ var editAttributeField = Backbone.View.extend( {
 			this.setValue( $el.filter(':checked').first().val() );
 		} else if ( 'checkbox' === this.model.attributes.type ) {
 			this.setValue( $el.is( ':checked' ) );
-		}  else if ( 'range' === this.model.attributes.type ) {
-			var rangeId =  '#' + e.target.id + '_indicator';
-			var rangeValue = e.target.value;
-			document.querySelector( rangeId ).value = rangeValue;
-			this.setValue( $el.val() );
 		} else {
 			this.setValue( $el.val() );
 		}
 
 		this.triggerCallbacks();
+	},
+
+	updateRangeOutput: function( e ) {
+		var range = e.target;
+		document.getElementById( range.id + '_indicator' ).value = range.value;
 	},
 
 	getValue: function() {

--- a/js/src/views/edit-attribute-field.js
+++ b/js/src/views/edit-attribute-field.js
@@ -17,6 +17,8 @@ var editAttributeField = Backbone.View.extend( {
 		'change input[type=date]':     'inputChanged',
 		'change input[type=url]':      'inputChanged',
 		'change input[type=range]':    'inputChanged',
+
+		'input input[type=range]':     'updateRangeOutput',
 	},
 
 	render: function() {
@@ -72,16 +74,16 @@ var editAttributeField = Backbone.View.extend( {
 			this.setValue( $el.filter(':checked').first().val() );
 		} else if ( 'checkbox' === this.model.attributes.type ) {
 			this.setValue( $el.is( ':checked' ) );
-		}  else if ( 'range' === this.model.attributes.type ) {
-			var rangeId =  '#' + e.target.id + '_indicator';
-			var rangeValue = e.target.value;
-			document.querySelector( rangeId ).value = rangeValue;
-			this.setValue( $el.val() );
 		} else {
 			this.setValue( $el.val() );
 		}
 
 		this.triggerCallbacks();
+	},
+
+	updateRangeOutput: function( e ) {
+		var range = e.target;
+		document.getElementById( range.id + '_indicator' ).value = range.value;
 	},
 
 	getValue: function() {


### PR DESCRIPTION
Enables smoother indicator updating, rather than waiting until selection
stops.

@davisshaver this is something like what I had in mind... 
