### PR TITLE
Pass explicit `false` value for falsey checkboxes

### DIFF
--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -461,6 +461,8 @@ Shortcode = Backbone.Model.extend({
 			// Skip empty attributes
 			if ( ( ! attr.get( 'value' ) ||  attr.get( 'value' ).length < 1 )  && ( attr.attributes.type != 'checkbox' ) ) {
 				return;
+			} else if ( ( ! attr.get( 'value' ) ||  attr.get( 'value' ).length < 1 )  && ( attr.attributes.type == 'checkbox' ) ) {
+				attr.set( 'value', 'false' );
 			}
 
 			attrs.push( attr.get( 'attr' ) + '="' + attr.get( 'value' ) + '"' );

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -449,8 +449,8 @@ Shortcode = Backbone.Model.extend({
 
 		this.get( 'attrs' ).each( function( attr ) {
 
-			// Skip empty attributes.
-			if ( ! attr.get( 'value' ) ||  attr.get( 'value' ).length < 1 ) {
+			// Skip empty attributes
+			if ( ( ! attr.get( 'value' ) ||  attr.get( 'value' ).length < 1 )  && ( attr.attributes.type != 'checkbox' ) ) {
 				return;
 			}
 

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -74,6 +74,11 @@ describe( "Shortcode Model", function() {
 				type:        'text',
 				value:       'test value',
 				placeholder: 'test placeholder',
+			}, {
+				attr:        'checkbox',
+				label:       'Attribute',
+				type:        'checkbox',
+				value:       'true',
 			}
 		],
 		inner_content: {
@@ -94,8 +99,9 @@ describe( "Shortcode Model", function() {
 
 	it( 'Attribute data set correctly..', function() {
 		expect( shortcode.get( 'attrs' ) instanceof ShortcodeAttributes ).toEqual( true );
-		expect( shortcode.get( 'attrs' ).length ).toEqual( 1 );
+		expect( shortcode.get( 'attrs' ).length ).toEqual( 2 );
 		expect( shortcode.get( 'attrs' ).first().get('type') ).toEqual( data.attrs[0].type );
+		expect( shortcode.get( 'attrs' ).last().get('type') ).toEqual( data.attrs[1].type );
 	});
 
 	it( 'Inner content set correctly..', function() {
@@ -114,16 +120,19 @@ describe( "Shortcode Model", function() {
 		var _shortcode = jQuery.extend( true, {}, shortcode );
 
 		// Test with attribute and with content.
-		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode attr="test value"]test content[/test_shortcode]' );
+		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode attr="test value" checkbox="true"]test content[/test_shortcode]' );
 
 		// Test without content.
 		_shortcode.get('inner_content').unset( 'value' );
-		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode attr="test value"]' );
+		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode attr="test value" checkbox="true"]' );
 
 		// Test without attributes
 		_shortcode.get( 'attrs' ).first().unset( 'value' );
-		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode]' );
+		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode checkbox="true"]' );
 
+		// Test with falsey checkbox
+		_shortcode.get( 'attrs' ).last().set( 'value', 'false' );
+		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode checkbox="false"]' );
 	});
 
 });

--- a/js-tests/src/shortcodeModelSpec.js
+++ b/js-tests/src/shortcodeModelSpec.js
@@ -18,6 +18,11 @@ describe( "Shortcode Model", function() {
 				type:        'text',
 				value:       'test value',
 				placeholder: 'test placeholder',
+			}, {
+				attr:        'checkbox',
+				label:       'Attribute',
+				type:        'checkbox',
+				value:       'true',
 			}
 		],
 		inner_content: {
@@ -38,8 +43,9 @@ describe( "Shortcode Model", function() {
 
 	it( 'Attribute data set correctly..', function() {
 		expect( shortcode.get( 'attrs' ) instanceof ShortcodeAttributes ).toEqual( true );
-		expect( shortcode.get( 'attrs' ).length ).toEqual( 1 );
+		expect( shortcode.get( 'attrs' ).length ).toEqual( 2 );
 		expect( shortcode.get( 'attrs' ).first().get('type') ).toEqual( data.attrs[0].type );
+		expect( shortcode.get( 'attrs' ).last().get('type') ).toEqual( data.attrs[1].type );
 	});
 
 	it( 'Inner content set correctly..', function() {
@@ -58,16 +64,19 @@ describe( "Shortcode Model", function() {
 		var _shortcode = jQuery.extend( true, {}, shortcode );
 
 		// Test with attribute and with content.
-		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode attr="test value"]test content[/test_shortcode]' );
+		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode attr="test value" checkbox="true"]test content[/test_shortcode]' );
 
 		// Test without content.
 		_shortcode.get('inner_content').unset( 'value' );
-		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode attr="test value"]' );
+		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode attr="test value" checkbox="true"]' );
 
 		// Test without attributes
 		_shortcode.get( 'attrs' ).first().unset( 'value' );
-		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode]' );
+		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode checkbox="true"]' );
 
+		// Test with falsey checkbox
+		_shortcode.get( 'attrs' ).last().set( 'value', 'false' );
+		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode checkbox="false"]' );
 	});
 
 });

--- a/js/build/field-color.js
+++ b/js/build/field-color.js
@@ -165,8 +165,8 @@ Shortcode = Backbone.Model.extend({
 
 		this.get( 'attrs' ).each( function( attr ) {
 
-			// Skip empty attributes.
-			if ( ! attr.get( 'value' ) ||  attr.get( 'value' ).length < 1 ) {
+			// Skip empty attributes
+			if ( ( ! attr.get( 'value' ) ||  attr.get( 'value' ).length < 1 )  && ( attr.attributes.type != 'checkbox' ) ) {
 				return;
 			}
 

--- a/js/build/field-color.js
+++ b/js/build/field-color.js
@@ -168,6 +168,8 @@ Shortcode = Backbone.Model.extend({
 			// Skip empty attributes
 			if ( ( ! attr.get( 'value' ) ||  attr.get( 'value' ).length < 1 )  && ( attr.attributes.type != 'checkbox' ) ) {
 				return;
+			} else if ( ( ! attr.get( 'value' ) ||  attr.get( 'value' ).length < 1 )  && ( attr.attributes.type == 'checkbox' ) ) {
+				attr.set( 'value', 'false' );
 			}
 
 			attrs.push( attr.get( 'attr' ) + '="' + attr.get( 'value' ) + '"' );

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -198,8 +198,8 @@ Shortcode = Backbone.Model.extend({
 
 		this.get( 'attrs' ).each( function( attr ) {
 
-			// Skip empty attributes.
-			if ( ! attr.get( 'value' ) ||  attr.get( 'value' ).length < 1 ) {
+			// Skip empty attributes
+			if ( ( ! attr.get( 'value' ) ||  attr.get( 'value' ).length < 1 )  && ( attr.attributes.type != 'checkbox' ) ) {
 				return;
 			}
 

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -201,6 +201,8 @@ Shortcode = Backbone.Model.extend({
 			// Skip empty attributes
 			if ( ( ! attr.get( 'value' ) ||  attr.get( 'value' ).length < 1 )  && ( attr.attributes.type != 'checkbox' ) ) {
 				return;
+			} else if ( ( ! attr.get( 'value' ) ||  attr.get( 'value' ).length < 1 )  && ( attr.attributes.type == 'checkbox' ) ) {
+				attr.set( 'value', 'false' );
 			}
 
 			attrs.push( attr.get( 'attr' ) + '="' + attr.get( 'value' ) + '"' );

--- a/js/src/models/shortcode.js
+++ b/js/src/models/shortcode.js
@@ -66,8 +66,8 @@ Shortcode = Backbone.Model.extend({
 
 		this.get( 'attrs' ).each( function( attr ) {
 
-			// Skip empty attributes.
-			if ( ! attr.get( 'value' ) ||  attr.get( 'value' ).length < 1 ) {
+			// Skip empty attributes
+			if ( ( ! attr.get( 'value' ) ||  attr.get( 'value' ).length < 1 )  && ( attr.attributes.type != 'checkbox' ) ) {
 				return;
 			}
 

--- a/js/src/models/shortcode.js
+++ b/js/src/models/shortcode.js
@@ -69,6 +69,8 @@ Shortcode = Backbone.Model.extend({
 			// Skip empty attributes
 			if ( ( ! attr.get( 'value' ) ||  attr.get( 'value' ).length < 1 )  && ( attr.attributes.type != 'checkbox' ) ) {
 				return;
+			} else if ( ( ! attr.get( 'value' ) ||  attr.get( 'value' ).length < 1 )  && ( attr.attributes.type == 'checkbox' ) ) {
+				attr.set( 'value', 'false' );
 			}
 
 			attrs.push( attr.get( 'attr' ) + '="' + attr.get( 'value' ) + '"' );


### PR DESCRIPTION
Checkbox values will be passed to the shortcode for both `true` and `false` states.

See https://github.com/fusioneng/Shortcake/issues/359
