### PR TITLE
Add CSS utility classes to fields

### DIFF
--- a/inc/fields/class-field-attachment.php
+++ b/inc/fields/class-field-attachment.php
@@ -90,7 +90,7 @@ class Shortcake_Field_Attachment {
 		?>
 
 		<script type="text/html" id="tmpl-fusion-shortcake-field-attachment">
-			<div class="field-block ui-field-attachment ui-attribute-{{ data.attr }}">
+			<div class="field-block shortcode-ui-field-attachment shortcode-ui-attribute-{{ data.attr }}">
 				<label for="{{ data.attr }}">{{ data.label }}</label>
 				<div class="shortcake-attachment-preview attachment-preview attachment">
 					<button id="{{ data.attr }}" class="button button-small add">{{ data.addButton }}</button>

--- a/inc/fields/class-field-attachment.php
+++ b/inc/fields/class-field-attachment.php
@@ -90,7 +90,7 @@ class Shortcake_Field_Attachment {
 		?>
 
 		<script type="text/html" id="tmpl-fusion-shortcake-field-attachment">
-			<div class="field-block">
+			<div class="field-block ui-field-attachment ui-attribute-{{ data.attr }}">
 				<label for="{{ data.attr }}">{{ data.label }}</label>
 				<div class="shortcake-attachment-preview attachment-preview attachment">
 					<button id="{{ data.attr }}" class="button button-small add">{{ data.addButton }}</button>

--- a/inc/fields/class-field-color.php
+++ b/inc/fields/class-field-color.php
@@ -109,7 +109,7 @@ class Shortcake_Field_Color {
 		?>
 
 		<script type="text/html" id="tmpl-fusion-shortcake-field-color">
-			<div class="field-block">
+			<div class="field-block ui-field-color ui-attribute-{{ data.attr }}">
 				<label for="{{ data.attr }}">{{ data.label }}</label>
 				<input type="text" name="{{ data.attr }}" id="{{ data.attr }}" value="{{ data.value }}" data-default-color="{{ data.value }}" {{{ data.meta }}}/>
 				<# if ( typeof data.description == 'string' ) { #>

--- a/inc/fields/class-field-color.php
+++ b/inc/fields/class-field-color.php
@@ -109,7 +109,7 @@ class Shortcake_Field_Color {
 		?>
 
 		<script type="text/html" id="tmpl-fusion-shortcake-field-color">
-			<div class="field-block ui-field-color ui-attribute-{{ data.attr }}">
+			<div class="field-block shortcode-ui-field-color shortcode-ui-attribute-{{ data.attr }}">
 				<label for="{{ data.attr }}">{{ data.label }}</label>
 				<input type="text" name="{{ data.attr }}" id="{{ data.attr }}" value="{{ data.value }}" data-default-color="{{ data.value }}" {{{ data.meta }}}/>
 				<# if ( typeof data.description == 'string' ) { #>

--- a/inc/fields/class-field-post-select.php
+++ b/inc/fields/class-field-post-select.php
@@ -75,7 +75,7 @@ class Shortcode_UI_Field_Post_Select {
 		</style>
 
 		<script type="text/html" id="tmpl-shortcode-ui-field-post-select">
-			<div class="field-block ui-field-post-select ui-attribute-{{ data.attr }}">
+			<div class="field-block shortcode-ui-field-post-select shortcode-ui-attribute-{{ data.attr }}">
 				<label for="{{ data.id }}">{{ data.label }}</label>
 				<input type="text" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value }}" class="shortcode-ui-post-select" />
 			</div>

--- a/inc/fields/class-field-post-select.php
+++ b/inc/fields/class-field-post-select.php
@@ -75,7 +75,7 @@ class Shortcode_UI_Field_Post_Select {
 		</style>
 
 		<script type="text/html" id="tmpl-shortcode-ui-field-post-select">
-			<div class="field-block">
+			<div class="field-block ui-field-post-select ui-attribute-{{ data.attr }}">
 				<label for="{{ data.id }}">{{ data.label }}</label>
 				<input type="text" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value }}" class="shortcode-ui-post-select" />
 			</div>

--- a/inc/templates/edit-form.tpl.php
+++ b/inc/templates/edit-form.tpl.php
@@ -2,7 +2,7 @@
 	<form class="edit-shortcode-form">
 		<p><a href="#" class="edit-shortcode-form-cancel">&#8592; <?php esc_html_e( 'Back to list', 'shortcode-ui' ); ?></a></p>
 
-		<div class="edit-shortcode-form-fields shortcake-edit-{{ data.model.attributes.shortcode_tag }}"></div>
+		<div class="edit-shortcode-form-fields shortcode-ui-edit-{{ data.model.attributes.shortcode_tag }}"></div>
 	</form>
 </script>
 
@@ -16,7 +16,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-text">
-	<div class="field-block ui-field-text ui-attribute-{{ data.attr }}">
+	<div class="field-block shortcode-ui-field-text shortcode-ui-attribute-{{ data.attr }}">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<input type="text" class="regular-text" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value }}" {{{ data.meta }}}/>
 		<# if ( typeof data.description == 'string' ) { #>
@@ -26,7 +26,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-url">
-	<div class="field-block ui-field-url ui-attribute-{{ data.attr }}">
+	<div class="field-block shortcode-ui-field-url shortcode-ui-attribute-{{ data.attr }}">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<input type="url" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value }}" class="code" {{{ data.meta }}}/>
 		<# if ( typeof data.description == 'string' ) { #>
@@ -36,7 +36,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-textarea">
-	<div class="field-block ui-field-textarea ui-attribute-{{ data.attr }}">
+	<div class="field-block shortcode-ui-field-textarea shortcode-ui-attribute-{{ data.attr }}">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<textarea name="{{ data.attr }}" id="{{ data.id }}" {{{ data.meta }}}>{{ data.value }}</textarea>
 		<# if ( typeof data.description == 'string' ) { #>
@@ -46,7 +46,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-select">
-	<div class="field-block ui-field-select ui-attribute-{{ data.attr }}">
+	<div class="field-block shortcode-ui-field-select shortcode-ui-attribute-{{ data.attr }}">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<select name="{{ data.attr }}" id="{{ data.id }}" {{{ data.meta }}}>
 			<# _.each( data.options, function( label, value ) { #>
@@ -60,7 +60,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-radio">
-	<div class="field-block ui-field-radio ui-attribute-{{ data.attr }}">
+	<div class="field-block shortcode-ui-field-radio shortcode-ui-attribute-{{ data.attr }}">
 		<label>{{ data.label }}</label>
 		<# _.each( data.options, function( label, value ) { #>
 			<label>
@@ -75,7 +75,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-checkbox">
-	<div class="field-block ui-field-checkbox ui-attribute-{{ data.attr }}">
+	<div class="field-block shortcode-ui-field-checkbox shortcode-ui-attribute-{{ data.attr }}">
 		<label for="{{ data.id }}">
 			<input type="checkbox" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value }}" <# if ( 'true' == data.value ){ print('checked'); } #>>
 			{{ data.label }}
@@ -87,7 +87,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-email">
-	<div class="field-block ui-field-email ui-attribute-{{ data.attr }}">
+	<div class="field-block shortcode-ui-field-email shortcode-ui-attribute-{{ data.attr }}">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<input type="email" class="regular-text" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value}}" {{{ data.meta }}}/>
 		<# if ( typeof data.description == 'string' ) { #>
@@ -97,7 +97,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-number">
-	<div class="field-block ui-field-number ui-attribute-{{ data.attr }}">
+	<div class="field-block shortcode-ui-field-number shortcode-ui-attribute-{{ data.attr }}">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<input type="number" class="regular-text" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value}}" {{{ data.meta }}}/>
 		<# if ( typeof data.description == 'string' ) { #>
@@ -107,7 +107,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-hidden">
-	<div class="field-block ui-field-hidden ui-attribute-{{ data.attr }}">
+	<div class="field-block shortcode-ui-field-hidden shortcode-ui-attribute-{{ data.attr }}">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<input type="hidden" name="{{ data.attr }}" id="{{ data.id }}" value="true" {{{ data.meta }}}/>
 		<# if ( typeof data.description == 'string' ) { #>
@@ -117,7 +117,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-date">
-	<div class="field-block ui-field-date ui-attribute-{{ data.attr }}">
+	<div class="field-block shortcode-ui-field-date shortcode-ui-attribute-{{ data.attr }}">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<input type="date" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value }}" {{{ data.meta }}}/>
 		<# if ( typeof data.description == 'string' ) { #>
@@ -127,7 +127,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-content">
-	<div class="field-block ui-content ui-attribute-{{ data.attr }}">
+	<div class="field-block shortcode-ui-content shortcode-ui-attribute-{{ data.attr }}">
 		<label for="inner_content">{{ data.label }}</label>
 		<textarea id="inner_content" name="inner_content" class="content-edit" {{{ data.meta }}}>{{ data.value }}</textarea>
 		<# if ( typeof data.description == 'string' ) { #>
@@ -137,7 +137,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-range">
-	<div class="field-block ui-field-range ui-attribute-{{ data.attr }}">
+	<div class="field-block shortcode-ui-field-range shortcode-ui-attribute-{{ data.attr }}">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<div class="field-range-container">
 			<input type="range" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value}}" {{{ data.meta }}} />

--- a/inc/templates/edit-form.tpl.php
+++ b/inc/templates/edit-form.tpl.php
@@ -16,7 +16,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-text">
-	<div class="field-block ui-field-text">
+	<div class="field-block ui-field-text ui-attribute-{{ data.attr }}">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<input type="text" class="regular-text" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value }}" {{{ data.meta }}}/>
 		<# if ( typeof data.description == 'string' ) { #>
@@ -26,7 +26,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-url">
-	<div class="field-block ui-field-url">
+	<div class="field-block ui-field-url ui-attribute-{{ data.attr }}">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<input type="url" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value }}" class="code" {{{ data.meta }}}/>
 		<# if ( typeof data.description == 'string' ) { #>
@@ -36,7 +36,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-textarea">
-	<div class="field-block ui-field-textarea">
+	<div class="field-block ui-field-textarea ui-attribute-{{ data.attr }}">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<textarea name="{{ data.attr }}" id="{{ data.id }}" {{{ data.meta }}}>{{ data.value }}</textarea>
 		<# if ( typeof data.description == 'string' ) { #>
@@ -46,7 +46,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-select">
-	<div class="field-block ui-field-select">
+	<div class="field-block ui-field-select ui-attribute-{{ data.attr }}">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<select name="{{ data.attr }}" id="{{ data.id }}" {{{ data.meta }}}>
 			<# _.each( data.options, function( label, value ) { #>
@@ -60,7 +60,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-radio">
-	<div class="field-block ui-field-radio">
+	<div class="field-block ui-field-radio ui-attribute-{{ data.attr }}">
 		<label>{{ data.label }}</label>
 		<# _.each( data.options, function( label, value ) { #>
 			<label>
@@ -75,7 +75,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-checkbox">
-	<div class="field-block ui-field-checkbox">
+	<div class="field-block ui-field-checkbox ui-attribute-{{ data.attr }}">
 		<label for="{{ data.id }}">
 			<input type="checkbox" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value }}" <# if ( 'true' == data.value ){ print('checked'); } #>>
 			{{ data.label }}
@@ -87,7 +87,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-email">
-	<div class="field-block ui-field-email">
+	<div class="field-block ui-field-email ui-attribute-{{ data.attr }}">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<input type="email" class="regular-text" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value}}" {{{ data.meta }}}/>
 		<# if ( typeof data.description == 'string' ) { #>
@@ -97,7 +97,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-number">
-	<div class="field-block ui-field-number">
+	<div class="field-block ui-field-number ui-attribute-{{ data.attr }}">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<input type="number" class="regular-text" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value}}" {{{ data.meta }}}/>
 		<# if ( typeof data.description == 'string' ) { #>
@@ -107,7 +107,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-hidden">
-	<div class="field-block ui-field-hidden">
+	<div class="field-block ui-field-hidden ui-attribute-{{ data.attr }}">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<input type="hidden" name="{{ data.attr }}" id="{{ data.id }}" value="true" {{{ data.meta }}}/>
 		<# if ( typeof data.description == 'string' ) { #>
@@ -117,7 +117,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-date">
-	<div class="field-block ui-field-date">
+	<div class="field-block ui-field-date ui-attribute-{{ data.attr }}">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<input type="date" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value }}" {{{ data.meta }}}/>
 		<# if ( typeof data.description == 'string' ) { #>
@@ -127,7 +127,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-content">
-	<div class="field-block ui-content">
+	<div class="field-block ui-content ui-attribute-{{ data.attr }}">
 		<label for="inner_content">{{ data.label }}</label>
 		<textarea id="inner_content" name="inner_content" class="content-edit" {{{ data.meta }}}>{{ data.value }}</textarea>
 		<# if ( typeof data.description == 'string' ) { #>
@@ -137,7 +137,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-range">
-	<div class="field-block ui-field-range">
+	<div class="field-block ui-field-range ui-attribute-{{ data.attr }}">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<div class="field-range-container">
 			<input type="range" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value}}" {{{ data.meta }}} />

--- a/inc/templates/edit-form.tpl.php
+++ b/inc/templates/edit-form.tpl.php
@@ -2,7 +2,7 @@
 	<form class="edit-shortcode-form">
 		<p><a href="#" class="edit-shortcode-form-cancel">&#8592; <?php esc_html_e( 'Back to list', 'shortcode-ui' ); ?></a></p>
 
-		<div class="edit-shortcode-form-fields"></div>
+		<div class="edit-shortcode-form-fields shortcake-edit-{{data.model.attributes.shortcode_tag}}"></div>
 	</form>
 </script>
 

--- a/inc/templates/edit-form.tpl.php
+++ b/inc/templates/edit-form.tpl.php
@@ -2,7 +2,7 @@
 	<form class="edit-shortcode-form">
 		<p><a href="#" class="edit-shortcode-form-cancel">&#8592; <?php esc_html_e( 'Back to list', 'shortcode-ui' ); ?></a></p>
 
-		<div class="edit-shortcode-form-fields shortcake-edit-{{data.model.attributes.shortcode_tag}}"></div>
+		<div class="edit-shortcode-form-fields shortcake-edit-{{ data.model.attributes.shortcode_tag }}"></div>
 	</form>
 </script>
 
@@ -16,7 +16,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-text">
-	<div class="field-block">
+	<div class="field-block ui-field-text">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<input type="text" class="regular-text" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value }}" {{{ data.meta }}}/>
 		<# if ( typeof data.description == 'string' ) { #>
@@ -26,7 +26,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-url">
-	<div class="field-block">
+	<div class="field-block ui-field-url">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<input type="url" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value }}" class="code" {{{ data.meta }}}/>
 		<# if ( typeof data.description == 'string' ) { #>
@@ -36,7 +36,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-textarea">
-	<div class="field-block">
+	<div class="field-block ui-field-textarea">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<textarea name="{{ data.attr }}" id="{{ data.id }}" {{{ data.meta }}}>{{ data.value }}</textarea>
 		<# if ( typeof data.description == 'string' ) { #>
@@ -46,7 +46,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-select">
-	<div class="field-block">
+	<div class="field-block ui-field-select">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<select name="{{ data.attr }}" id="{{ data.id }}" {{{ data.meta }}}>
 			<# _.each( data.options, function( label, value ) { #>
@@ -60,7 +60,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-radio">
-	<div class="field-block">
+	<div class="field-block ui-field-radio">
 		<label>{{ data.label }}</label>
 		<# _.each( data.options, function( label, value ) { #>
 			<label>
@@ -75,7 +75,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-checkbox">
-	<div class="field-block">
+	<div class="field-block ui-field-checkbox">
 		<label for="{{ data.id }}">
 			<input type="checkbox" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value }}" <# if ( 'true' == data.value ){ print('checked'); } #>>
 			{{ data.label }}
@@ -87,7 +87,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-email">
-	<div class="field-block">
+	<div class="field-block ui-field-email">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<input type="email" class="regular-text" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value}}" {{{ data.meta }}}/>
 		<# if ( typeof data.description == 'string' ) { #>
@@ -97,7 +97,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-number">
-	<div class="field-block">
+	<div class="field-block ui-field-number">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<input type="number" class="regular-text" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value}}" {{{ data.meta }}}/>
 		<# if ( typeof data.description == 'string' ) { #>
@@ -107,7 +107,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-hidden">
-	<div class="field-block">
+	<div class="field-block ui-field-hidden">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<input type="hidden" name="{{ data.attr }}" id="{{ data.id }}" value="true" {{{ data.meta }}}/>
 		<# if ( typeof data.description == 'string' ) { #>
@@ -117,7 +117,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-date">
-	<div class="field-block">
+	<div class="field-block ui-field-date">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<input type="date" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value }}" {{{ data.meta }}}/>
 		<# if ( typeof data.description == 'string' ) { #>
@@ -127,7 +127,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-content">
-	<div class="field-block">
+	<div class="field-block ui-content">
 		<label for="inner_content">{{ data.label }}</label>
 		<textarea id="inner_content" name="inner_content" class="content-edit" {{{ data.meta }}}>{{ data.value }}</textarea>
 		<# if ( typeof data.description == 'string' ) { #>
@@ -137,7 +137,7 @@
 </script>
 
 <script type="text/html" id="tmpl-shortcode-ui-field-range">
-	<div class="field-block">
+	<div class="field-block ui-field-range">
 		<label for="{{ data.id }}">{{ data.label }}</label>
 		<div class="field-range-container">
 			<input type="range" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value}}" {{{ data.meta }}} />


### PR DESCRIPTION
It's currently almost impossible to add your own CSS to change the appearance of specific shortcodes and fields in the Shortcake UI modal.

This pull request adds a class to the outer body that provides the shortcode base which is currently being edited, as well as a class on each form field that displays the current attribute.

Open to changing the naming convention and any other feedback.

**Before**
![screen shot 2015-10-01 at 16 50 20](https://cloud.githubusercontent.com/assets/1207507/10224088/afd7d736-685c-11e5-8a46-9589ebdd7aaa.png)

**After**
![screen shot 2015-10-01 at 16 49 47](https://cloud.githubusercontent.com/assets/1207507/10224096/bad0edda-685c-11e5-8941-77f9e3c8ad84.png)

@danielbachhuber @goldenapples  
