### PR TITLE
Add "Fetcher" class for bulk fetching of shortcode previews

### DIFF
--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -68,6 +68,7 @@ class Shortcode_UI {
 		add_action( 'admin_enqueue_scripts', array( $this, 'action_admin_enqueue_scripts' ) );
 		add_action( 'wp_enqueue_editor',     array( $this, 'action_wp_enqueue_editor' ) );
 		add_action( 'wp_ajax_do_shortcode',  array( $this, 'handle_ajax_do_shortcode' ) );
+		add_action( 'wp_ajax_bulk_do_shortcode',  array( $this, 'handle_ajax_bulk_do_shortcode' ) );
 		add_filter( 'wp_editor_settings',    array( $this, 'filter_wp_editor_settings' ), 10, 2 );
 	}
 
@@ -292,27 +293,12 @@ class Shortcode_UI {
 	}
 
 	/**
-	 * Render a shortcode for preview in the TinyMCE editor.
+	 * Render a shortcode body for preview.
 	 */
-	public function handle_ajax_do_shortcode() {
+	private function render_shortcode_for_preview( $shortcode, $post_id = null ) {
 
-		// Don't sanitize shortcodes — can contain HTML kses doesn't allow (e.g. sourcecode shortcode)
-		if ( ! empty( $_POST['shortcode'] ) ) {
-			$shortcode = stripslashes( $_POST['shortcode'] );
-		} else {
-			$shortcode = null;
-		}
-		if ( isset( $_POST['post_id'] ) ) {
-			$post_id = intval( $_POST['post_id'] );
-		} else {
-			$post_id = null;
-		}
-
-		define( 'SHORTCODE_UI_DOING_PREVIEW', true );
-
-		if ( ! current_user_can( 'edit_post', $post_id ) || ! wp_verify_nonce( $_POST['nonce'], 'shortcode-ui-preview' ) ) {
-			echo esc_html__( "Something's rotten in the state of Denmark", 'shortcode-ui' );
-			exit;
+		if ( ! defined( 'SHORTCODE_UI_DOING_PREVIEW' ) ) {
+			define( 'SHORTCODE_UI_DOING_PREVIEW', true );
 		}
 
 		if ( ! empty( $post_id ) ) {
@@ -338,8 +324,67 @@ class Shortcode_UI {
 		 */
 		do_action( 'shortcode_ui_after_do_shortcode', $shortcode );
 
-		wp_send_json_success( ob_get_clean() );
-
+		return ob_get_clean();
 	}
 
+	/**
+	 * Render a shortcode for preview in the TinyMCE editor.
+	 */
+	public function handle_ajax_do_shortcode() {
+
+		// Don't sanitize shortcodes — can contain HTML kses doesn't allow (e.g. sourcecode shortcode)
+		if ( ! empty( $_POST['shortcode'] ) ) {
+			$shortcode = stripslashes( $_POST['shortcode'] );
+		} else {
+			$shortcode = null;
+		}
+		if ( isset( $_POST['post_id'] ) ) {
+			$post_id = intval( $_POST['post_id'] );
+		} else {
+			$post_id = null;
+		}
+
+		if ( ! current_user_can( 'edit_post', $post_id ) || ! wp_verify_nonce( $_POST['nonce'], 'shortcode-ui-preview' ) ) {
+			echo esc_html__( "Something's rotten in the state of Denmark", 'shortcode-ui' );
+			exit;
+		}
+
+		wp_send_json_success( $this->render_shortcode_for_preview() );
+	}
+
+	/**
+	 * Get a bunch of shortcodes to render in preview.
+	 */
+	public function handle_ajax_bulk_do_shortcode() {
+
+		if ( is_array( $_POST['queries'] ) ) {
+
+			$responses = array();
+
+			foreach ( $_POST['queries'] as $posted_query ) {
+
+				// Don't sanitize shortcodes — can contain HTML kses doesn't allow (e.g. sourcecode shortcode)
+				if ( ! empty( $posted_query['shortcode'] ) ) {
+					$shortcode = stripslashes( $posted_query['shortcode'] );
+				} else {
+					$shortcode = null;
+				}
+				if ( isset( $posted_query['post_id'] ) ) {
+					$post_id = intval( $posted_query['post_id'] );
+				} else {
+					$post_id = null;
+				}
+
+				array_push( $responses, array(
+					'query' => $posted_query,
+					'counter' => $posted_query['counter'],
+					'response' => $this->render_shortcode_for_preview( $shortcode, $post_id )
+				) );
+			}
+
+			wp_send_json_success( $responses );
+			exit;
+		}
+
+	}
 }

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -67,7 +67,6 @@ class Shortcode_UI {
 	private function setup_actions() {
 		add_action( 'admin_enqueue_scripts',     array( $this, 'action_admin_enqueue_scripts' ) );
 		add_action( 'wp_enqueue_editor',         array( $this, 'action_wp_enqueue_editor' ) );
-		add_action( 'wp_ajax_do_shortcode',      array( $this, 'handle_ajax_do_shortcode' ) );
 		add_action( 'wp_ajax_bulk_do_shortcode', array( $this, 'handle_ajax_bulk_do_shortcode' ) );
 		add_filter( 'wp_editor_settings',        array( $this, 'filter_wp_editor_settings' ), 10, 2 );
 	}
@@ -328,32 +327,7 @@ class Shortcode_UI {
 	}
 
 	/**
-	 * Render a shortcode for preview in the TinyMCE editor.
-	 */
-	public function handle_ajax_do_shortcode() {
-
-		// Don't sanitize shortcodes — can contain HTML kses doesn't allow (e.g. sourcecode shortcode)
-		if ( ! empty( $_POST['shortcode'] ) ) {
-			$shortcode = stripslashes( $_POST['shortcode'] );
-		} else {
-			$shortcode = null;
-		}
-		if ( isset( $_POST['post_id'] ) ) {
-			$post_id = intval( $_POST['post_id'] );
-		} else {
-			$post_id = null;
-		}
-
-		if ( ! current_user_can( 'edit_post', $post_id ) || ! wp_verify_nonce( $_POST['nonce'], 'shortcode-ui-preview' ) ) {
-			echo esc_html__( "Something's rotten in the state of Denmark", 'shortcode-ui' );
-			exit;
-		}
-
-		wp_send_json_success( $this->render_shortcode_for_preview() );
-	}
-
-	/**
-	 * Get a bunch of shortcodes to render in preview.
+	 * Get a bunch of shortcodes to render in MCE preview.
 	 */
 	public function handle_ajax_bulk_do_shortcode() {
 

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -65,11 +65,11 @@ class Shortcode_UI {
 	 * Setup plugin actions.
 	 */
 	private function setup_actions() {
-		add_action( 'admin_enqueue_scripts', array( $this, 'action_admin_enqueue_scripts' ) );
-		add_action( 'wp_enqueue_editor',     array( $this, 'action_wp_enqueue_editor' ) );
-		add_action( 'wp_ajax_do_shortcode',  array( $this, 'handle_ajax_do_shortcode' ) );
-		add_action( 'wp_ajax_bulk_do_shortcode',  array( $this, 'handle_ajax_bulk_do_shortcode' ) );
-		add_filter( 'wp_editor_settings',    array( $this, 'filter_wp_editor_settings' ), 10, 2 );
+		add_action( 'admin_enqueue_scripts',     array( $this, 'action_admin_enqueue_scripts' ) );
+		add_action( 'wp_enqueue_editor',         array( $this, 'action_wp_enqueue_editor' ) );
+		add_action( 'wp_ajax_do_shortcode',      array( $this, 'handle_ajax_do_shortcode' ) );
+		add_action( 'wp_ajax_bulk_do_shortcode', array( $this, 'handle_ajax_bulk_do_shortcode' ) );
+		add_filter( 'wp_editor_settings',        array( $this, 'filter_wp_editor_settings' ), 10, 2 );
 	}
 
 	/**

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -306,7 +306,7 @@ class Shortcode_UI {
 			global $post;
 			$post = get_post( $post_id );
 			setup_postdata( $post );
-			// @codingStandardsIgnoreStart
+			// @codingStandardsIgnoreEnd
 		}
 
 		ob_start();
@@ -375,11 +375,10 @@ class Shortcode_UI {
 					$post_id = null;
 				}
 
-				array_push( $responses, array(
+				$responses[ $posted_query['counter'] ] = array(
 					'query' => $posted_query,
-					'counter' => $posted_query['counter'],
 					'response' => $this->render_shortcode_for_preview( $shortcode, $post_id )
-				) );
+				);
 			}
 
 			wp_send_json_success( $responses );

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -377,7 +377,7 @@ class Shortcode_UI {
 
 				$responses[ $posted_query['counter'] ] = array(
 					'query' => $posted_query,
-					'response' => $this->render_shortcode_for_preview( $shortcode, $post_id )
+					'response' => $this->render_shortcode_for_preview( $shortcode, $post_id ),
 				);
 			}
 

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -180,7 +180,7 @@ describe( 'Shortcode View Constructor', function(){
 });
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"../../js/src/models/shortcode":11,"../../js/src/utils/shortcode-view-constructor":12,"../../js/src/utils/sui":13}],5:[function(require,module,exports){
+},{"../../js/src/models/shortcode":11,"../../js/src/utils/shortcode-view-constructor":13,"../../js/src/utils/sui":14}],5:[function(require,module,exports){
 (function (global){
 var Shortcode = require('./../../../js/src/models/shortcode.js');
 var MceViewConstructor = require('./../../../js/src/utils/shortcode-view-constructor.js');
@@ -339,7 +339,7 @@ describe( "MCE View Constructor", function() {
 } );
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./../../../js/src/models/shortcode.js":11,"./../../../js/src/utils/shortcode-view-constructor.js":12,"./../../../js/src/utils/sui.js":13}],6:[function(require,module,exports){
+},{"./../../../js/src/models/shortcode.js":11,"./../../../js/src/utils/shortcode-view-constructor.js":13,"./../../../js/src/utils/sui.js":14}],6:[function(require,module,exports){
 var Shortcodes = require('./../../../js/src/collections/shortcodes.js');
 var sui = require('./../../../js/src/utils/sui.js');
 
@@ -356,7 +356,7 @@ describe( "SUI Util", function() {
 
 } );
 
-},{"./../../../js/src/collections/shortcodes.js":8,"./../../../js/src/utils/sui.js":13}],7:[function(require,module,exports){
+},{"./../../../js/src/collections/shortcodes.js":8,"./../../../js/src/utils/sui.js":14}],7:[function(require,module,exports){
 (function (global){
 var Backbone = (typeof window !== "undefined" ? window['Backbone'] : typeof global !== "undefined" ? global['Backbone'] : null);
 var ShortcodeAttribute = require('./../models/shortcode-attribute.js');
@@ -545,9 +545,80 @@ module.exports = Shortcode;
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 },{"./../collections/shortcode-attributes.js":7,"./inner-content.js":9}],12:[function(require,module,exports){
 (function (global){
+var $ = (typeof window !== "undefined" ? window['jQuery'] : typeof global !== "undefined" ? global['jQuery'] : null);
+var _ = (typeof window !== "undefined" ? window['_'] : typeof global !== "undefined" ? global['_'] : null);
+
+var Fetcher = (function() {
+	var fetcher = this;
+
+	this.counter = 0;
+	this.queries = [];
+	this.timeout = null;
+
+	/**
+	 * Add a query to the queue.
+	 *
+	 * Returns a promise that will be resolved when the query is successfully
+	 * returned.
+	 */
+	this.queueToFetch = function( query ) {
+		var fetchPromise = new $.Deferred();
+
+		query.counter = ++fetcher.counter;
+
+		fetcher.queries.push({
+			promise: fetchPromise,
+			query: query,
+			counter: query.counter
+		});
+
+		if ( ! fetcher.timeout ) {
+			fetcher.timeout = setTimeout(
+				fetcher.fetchAll, 500
+			);
+		}
+		return fetchPromise;
+	};
+
+	/**
+	 * Execute all queued queries.
+	 *
+	 * Resolves their respective promises.
+	 */
+	this.fetchAll = function() {
+		var request = $.post( ajaxurl + '?action=bulk_do_shortcode', {
+				queries: _.pluck( fetcher.queries, 'query' )
+			}
+		);
+
+		request.done( function( response ) {
+			_.each( response.data, function( result ) {
+				var matchedQuery = _.findWhere( fetcher.queries, {
+					counter: parseInt( result.counter ),
+				});
+				fetcher.queries = _.without( fetcher.queries, matchedQuery );
+				matchedQuery.promise.resolve( result );
+			} );
+		} );
+	};
+
+	// Public API methods available
+	return {
+		queueToFetch : this.queueToFetch,
+		fetchAll     : this.fetchAll
+	};
+
+})();
+
+module.exports = Fetcher;
+
+}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+},{}],13:[function(require,module,exports){
+(function (global){
 var sui = require('./sui.js'),
-    wp = (typeof window !== "undefined" ? window['wp'] : typeof global !== "undefined" ? global['wp'] : null),
-    $ = (typeof window !== "undefined" ? window['jQuery'] : typeof global !== "undefined" ? global['jQuery'] : null);
+	fetcher = require('./fetcher.js'),
+	wp = (typeof window !== "undefined" ? window['wp'] : typeof global !== "undefined" ? global['wp'] : null),
+	$ = (typeof window !== "undefined" ? window['jQuery'] : typeof global !== "undefined" ? global['jQuery'] : null);
 
 /**
  * Generic shortcode mce view constructor.
@@ -556,8 +627,24 @@ var sui = require('./sui.js'),
 var shortcodeViewConstructor = {
 
 	initialize: function( options ) {
+		var self = this;
+
 		this.shortcodeModel = this.getShortcodeModel( this.shortcode );
-		this.fetch();
+		this.fetching = this.delayedFetch();
+
+		this.fetching.done( function( queryResponse ) {
+			var response = queryResponse.response;
+			if ( '' === response ) {
+				self.content = '<span class="shortcake-notice shortcake-empty">' + self.shortcodeModel.formatShortcode() + '</span>';
+			} else {
+				self.content = response;
+			}
+		}).fail( function() {
+			self.content = '<span class="shortcake-error">' + shortcodeUIData.strings.mce_view_error + '</span>';
+		} ).always( function() {
+			delete self.fetching;
+			self.render( null, true );
+		} );
 	},
 
 	/**
@@ -596,6 +683,14 @@ var shortcodeViewConstructor = {
 
 		return shortcodeModel;
 
+	},
+
+	delayedFetch : function() {
+		return /* this.fetching ||*/ fetcher.queueToFetch({
+			post_id: $( '#post_ID' ).val(),
+			shortcode: this.shortcodeModel.formatShortcode(),
+			nonce: shortcodeUIData.nonces.preview,
+		});
 	},
 
 	/**
@@ -878,7 +973,7 @@ var shortcodeViewConstructor = {
 module.exports = shortcodeViewConstructor;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./sui.js":13}],13:[function(require,module,exports){
+},{"./fetcher.js":12,"./sui.js":14}],14:[function(require,module,exports){
 var Shortcodes = require('./../collections/shortcodes.js');
 
 window.Shortcode_UI = window.Shortcode_UI || {

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -586,20 +586,27 @@ var Fetcher = (function() {
 	 * Resolves their respective promises.
 	 */
 	this.fetchAll = function() {
+		delete fetcher.timeout;
+
+		if ( 0 === fetcher.queries.length ) {
+			return;
+		}
+
 		var request = $.post( ajaxurl + '?action=bulk_do_shortcode', {
 				queries: _.pluck( fetcher.queries, 'query' )
 			}
 		);
-
-		delete fetcher.timeout;
 
 		request.done( function( response ) {
 			_.each( response.data, function( result, index ) {
 				var matchedQuery = _.findWhere( fetcher.queries, {
 					counter: parseInt( index ),
 				});
-				fetcher.queries = _.without( fetcher.queries, matchedQuery );
-				matchedQuery.promise.resolve( result );
+
+				if ( matchedQuery ) {
+					fetcher.queries = _.without( fetcher.queries, matchedQuery );
+					matchedQuery.promise.resolve( result );
+				}
 			} );
 		} );
 	};

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -695,7 +695,7 @@ var shortcodeViewConstructor = {
 	},
 
 	delayedFetch : function() {
-		return /* this.fetching ||*/ fetcher.queueToFetch({
+		return fetcher.queueToFetch({
 			post_id: $( '#post_ID' ).val(),
 			shortcode: this.shortcodeModel.formatShortcode(),
 			nonce: shortcodeUIData.nonces.preview,

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -573,10 +573,9 @@ var Fetcher = (function() {
 		});
 
 		if ( ! fetcher.timeout ) {
-			fetcher.timeout = setTimeout(
-				fetcher.fetchAll, 200
-			);
+			fetcher.timeout = setTimeout( fetcher.fetchAll );
 		}
+
 		return fetchPromise;
 	};
 

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -574,7 +574,7 @@ var Fetcher = (function() {
 
 		if ( ! fetcher.timeout ) {
 			fetcher.timeout = setTimeout(
-				fetcher.fetchAll, 500
+				fetcher.fetchAll, 200
 			);
 		}
 		return fetchPromise;
@@ -590,6 +590,8 @@ var Fetcher = (function() {
 				queries: _.pluck( fetcher.queries, 'query' )
 			}
 		);
+
+		delete fetcher.timeout;
 
 		request.done( function( response ) {
 			_.each( response.data, function( result ) {

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -594,9 +594,9 @@ var Fetcher = (function() {
 		delete fetcher.timeout;
 
 		request.done( function( response ) {
-			_.each( response.data, function( result ) {
+			_.each( response.data, function( result, index ) {
 				var matchedQuery = _.findWhere( fetcher.queries, {
-					counter: parseInt( result.counter ),
+					counter: parseInt( index ),
 				});
 				fetcher.queries = _.without( fetcher.queries, matchedQuery );
 				matchedQuery.promise.resolve( result );

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -323,9 +323,9 @@ var Fetcher = (function() {
 		delete fetcher.timeout;
 
 		request.done( function( response ) {
-			_.each( response.data, function( result ) {
+			_.each( response.data, function( result, index ) {
 				var matchedQuery = _.findWhere( fetcher.queries, {
-					counter: parseInt( result.counter ),
+					counter: parseInt( index ),
 				});
 				fetcher.queries = _.without( fetcher.queries, matchedQuery );
 				matchedQuery.promise.resolve( result );

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -302,10 +302,9 @@ var Fetcher = (function() {
 		});
 
 		if ( ! fetcher.timeout ) {
-			fetcher.timeout = setTimeout(
-				fetcher.fetchAll, 200
-			);
+			fetcher.timeout = setTimeout( fetcher.fetchAll );
 		}
+
 		return fetchPromise;
 	};
 

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -303,7 +303,7 @@ var Fetcher = (function() {
 
 		if ( ! fetcher.timeout ) {
 			fetcher.timeout = setTimeout(
-				fetcher.fetchAll, 500
+				fetcher.fetchAll, 200
 			);
 		}
 		return fetchPromise;
@@ -319,6 +319,8 @@ var Fetcher = (function() {
 				queries: _.pluck( fetcher.queries, 'query' )
 			}
 		);
+
+		delete fetcher.timeout;
 
 		request.done( function( response ) {
 			_.each( response.data, function( result ) {

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -424,7 +424,7 @@ var shortcodeViewConstructor = {
 	},
 
 	delayedFetch : function() {
-		return /* this.fetching ||*/ fetcher.queueToFetch({
+		return fetcher.queueToFetch({
 			post_id: $( '#post_ID' ).val(),
 			shortcode: this.shortcodeModel.formatShortcode(),
 			nonce: shortcodeUIData.nonces.preview,

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -89,7 +89,7 @@ sui.controllers.MediaController = MediaController;
 module.exports = MediaController;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./../collections/shortcodes.js":2,"./../utils/sui.js":9}],4:[function(require,module,exports){
+},{"./../collections/shortcodes.js":2,"./../utils/sui.js":10}],4:[function(require,module,exports){
 (function (global){
 var Backbone = (typeof window !== "undefined" ? window['Backbone'] : typeof global !== "undefined" ? global['Backbone'] : null);
 
@@ -272,11 +272,82 @@ $(document).ready(function(){
 });
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./collections/shortcodes.js":2,"./utils/shortcode-view-constructor.js":8,"./utils/sui.js":9,"./views/media-frame.js":17}],8:[function(require,module,exports){
+},{"./collections/shortcodes.js":2,"./utils/shortcode-view-constructor.js":9,"./utils/sui.js":10,"./views/media-frame.js":18}],8:[function(require,module,exports){
+(function (global){
+var $ = (typeof window !== "undefined" ? window['jQuery'] : typeof global !== "undefined" ? global['jQuery'] : null);
+var _ = (typeof window !== "undefined" ? window['_'] : typeof global !== "undefined" ? global['_'] : null);
+
+var Fetcher = (function() {
+	var fetcher = this;
+
+	this.counter = 0;
+	this.queries = [];
+	this.timeout = null;
+
+	/**
+	 * Add a query to the queue.
+	 *
+	 * Returns a promise that will be resolved when the query is successfully
+	 * returned.
+	 */
+	this.queueToFetch = function( query ) {
+		var fetchPromise = new $.Deferred();
+
+		query.counter = ++fetcher.counter;
+
+		fetcher.queries.push({
+			promise: fetchPromise,
+			query: query,
+			counter: query.counter
+		});
+
+		if ( ! fetcher.timeout ) {
+			fetcher.timeout = setTimeout(
+				fetcher.fetchAll, 500
+			);
+		}
+		return fetchPromise;
+	};
+
+	/**
+	 * Execute all queued queries.
+	 *
+	 * Resolves their respective promises.
+	 */
+	this.fetchAll = function() {
+		var request = $.post( ajaxurl + '?action=bulk_do_shortcode', {
+				queries: _.pluck( fetcher.queries, 'query' )
+			}
+		);
+
+		request.done( function( response ) {
+			_.each( response.data, function( result ) {
+				var matchedQuery = _.findWhere( fetcher.queries, {
+					counter: parseInt( result.counter ),
+				});
+				fetcher.queries = _.without( fetcher.queries, matchedQuery );
+				matchedQuery.promise.resolve( result );
+			} );
+		} );
+	};
+
+	// Public API methods available
+	return {
+		queueToFetch : this.queueToFetch,
+		fetchAll     : this.fetchAll
+	};
+
+})();
+
+module.exports = Fetcher;
+
+}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+},{}],9:[function(require,module,exports){
 (function (global){
 var sui = require('./sui.js'),
-    wp = (typeof window !== "undefined" ? window['wp'] : typeof global !== "undefined" ? global['wp'] : null),
-    $ = (typeof window !== "undefined" ? window['jQuery'] : typeof global !== "undefined" ? global['jQuery'] : null);
+	fetcher = require('./fetcher.js'),
+	wp = (typeof window !== "undefined" ? window['wp'] : typeof global !== "undefined" ? global['wp'] : null),
+	$ = (typeof window !== "undefined" ? window['jQuery'] : typeof global !== "undefined" ? global['jQuery'] : null);
 
 /**
  * Generic shortcode mce view constructor.
@@ -285,8 +356,24 @@ var sui = require('./sui.js'),
 var shortcodeViewConstructor = {
 
 	initialize: function( options ) {
+		var self = this;
+
 		this.shortcodeModel = this.getShortcodeModel( this.shortcode );
-		this.fetch();
+		this.fetching = this.delayedFetch();
+
+		this.fetching.done( function( queryResponse ) {
+			var response = queryResponse.response;
+			if ( '' === response ) {
+				self.content = '<span class="shortcake-notice shortcake-empty">' + self.shortcodeModel.formatShortcode() + '</span>';
+			} else {
+				self.content = response;
+			}
+		}).fail( function() {
+			self.content = '<span class="shortcake-error">' + shortcodeUIData.strings.mce_view_error + '</span>';
+		} ).always( function() {
+			delete self.fetching;
+			self.render( null, true );
+		} );
 	},
 
 	/**
@@ -325,6 +412,14 @@ var shortcodeViewConstructor = {
 
 		return shortcodeModel;
 
+	},
+
+	delayedFetch : function() {
+		return /* this.fetching ||*/ fetcher.queueToFetch({
+			post_id: $( '#post_ID' ).val(),
+			shortcode: this.shortcodeModel.formatShortcode(),
+			nonce: shortcodeUIData.nonces.preview,
+		});
 	},
 
 	/**
@@ -607,7 +702,7 @@ var shortcodeViewConstructor = {
 module.exports = shortcodeViewConstructor;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./sui.js":9}],9:[function(require,module,exports){
+},{"./fetcher.js":8,"./sui.js":10}],10:[function(require,module,exports){
 var Shortcodes = require('./../collections/shortcodes.js');
 
 window.Shortcode_UI = window.Shortcode_UI || {
@@ -618,7 +713,7 @@ window.Shortcode_UI = window.Shortcode_UI || {
 
 module.exports = window.Shortcode_UI;
 
-},{"./../collections/shortcodes.js":2}],10:[function(require,module,exports){
+},{"./../collections/shortcodes.js":2}],11:[function(require,module,exports){
 var sui = require('./../utils/sui.js');
 
 var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
@@ -828,7 +923,7 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 module.exports = sui.views.editAttributeFieldAttachment = editAttributeFieldAttachment;
 
 
-},{"./../utils/sui.js":9}],11:[function(require,module,exports){
+},{"./../utils/sui.js":10}],12:[function(require,module,exports){
 (function (global){
 var sui = require('./../utils/sui.js'),
     editAttributeField = require('./edit-attribute-field.js'),
@@ -886,7 +981,7 @@ sui.views.editAttributeFieldColor = editAttributeField.extend({
 
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./../utils/sui.js":9,"./edit-attribute-field.js":13}],12:[function(require,module,exports){
+},{"./../utils/sui.js":10,"./edit-attribute-field.js":14}],13:[function(require,module,exports){
 ( function( $ ) {
 
 	var sui = window.Shortcode_UI;
@@ -1082,7 +1177,7 @@ sui.views.editAttributeFieldColor = editAttributeField.extend({
 
 } )( jQuery );
 
-},{}],13:[function(require,module,exports){
+},{}],14:[function(require,module,exports){
 (function (global){
 var Backbone     = (typeof window !== "undefined" ? window['Backbone'] : typeof global !== "undefined" ? global['Backbone'] : null),
 	sui          = require('./../utils/sui.js'),
@@ -1230,7 +1325,7 @@ sui.views.editAttributeField = editAttributeField;
 module.exports = editAttributeField;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./../utils/sui.js":9}],14:[function(require,module,exports){
+},{"./../utils/sui.js":10}],15:[function(require,module,exports){
 (function (global){
 var wp = (typeof window !== "undefined" ? window['wp'] : typeof global !== "undefined" ? global['wp'] : null),
 	sui = require('./../utils/sui.js'),
@@ -1314,7 +1409,7 @@ var EditShortcodeForm = wp.Backbone.View.extend({
 module.exports = EditShortcodeForm;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./../utils/sui.js":9,"./edit-attribute-field-attachment.js":10,"./edit-attribute-field-color.js":11,"./edit-attribute-field-post-select.js":12,"./edit-attribute-field.js":13}],15:[function(require,module,exports){
+},{"./../utils/sui.js":10,"./edit-attribute-field-attachment.js":11,"./edit-attribute-field-color.js":12,"./edit-attribute-field-post-select.js":13,"./edit-attribute-field.js":14}],16:[function(require,module,exports){
 (function (global){
 var wp = (typeof window !== "undefined" ? window['wp'] : typeof global !== "undefined" ? global['wp'] : null),
 	$ = (typeof window !== "undefined" ? window['jQuery'] : typeof global !== "undefined" ? global['jQuery'] : null);
@@ -1348,7 +1443,7 @@ var insertShortcodeListItem = wp.Backbone.View.extend({
 module.exports = insertShortcodeListItem;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],16:[function(require,module,exports){
+},{}],17:[function(require,module,exports){
 (function (global){
 var wp = (typeof window !== "undefined" ? window['wp'] : typeof global !== "undefined" ? global['wp'] : null);
 var Backbone = (typeof window !== "undefined" ? window['Backbone'] : typeof global !== "undefined" ? global['Backbone'] : null);
@@ -1395,7 +1490,7 @@ var insertShortcodeList = wp.Backbone.View.extend({
 module.exports = insertShortcodeList;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./../collections/shortcodes.js":2,"./insert-shortcode-list-item.js":15}],17:[function(require,module,exports){
+},{"./../collections/shortcodes.js":2,"./insert-shortcode-list-item.js":16}],18:[function(require,module,exports){
 (function (global){
 var wp = (typeof window !== "undefined" ? window['wp'] : typeof global !== "undefined" ? global['wp'] : null),
 	$ = (typeof window !== "undefined" ? window['jQuery'] : typeof global !== "undefined" ? global['jQuery'] : null),
@@ -1519,7 +1614,7 @@ var mediaFrame = postMediaFrame.extend( {
 module.exports = mediaFrame;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./../controllers/media-controller.js":3,"./media-toolbar":18,"./shortcode-ui":21}],18:[function(require,module,exports){
+},{"./../controllers/media-controller.js":3,"./media-toolbar":19,"./shortcode-ui":22}],19:[function(require,module,exports){
 (function (global){
 var wp = (typeof window !== "undefined" ? window['wp'] : typeof global !== "undefined" ? global['wp'] : null);
 
@@ -1551,7 +1646,7 @@ var Toolbar = wp.media.view.Toolbar.extend({
 module.exports = Toolbar;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],19:[function(require,module,exports){
+},{}],20:[function(require,module,exports){
 (function (global){
 var wp = (typeof window !== "undefined" ? window['wp'] : typeof global !== "undefined" ? global['wp'] : null);
 sui = require('./../utils/sui.js');
@@ -1599,7 +1694,7 @@ sui.views.SearchShortcode = SearchShortcode;
 module.exports = SearchShortcode;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./../utils/sui.js":9}],20:[function(require,module,exports){
+},{"./../utils/sui.js":10}],21:[function(require,module,exports){
 (function (global){
 var Backbone = (typeof window !== "undefined" ? window['Backbone'] : typeof global !== "undefined" ? global['Backbone'] : null),
     $ = (typeof window !== "undefined" ? window['jQuery'] : typeof global !== "undefined" ? global['jQuery'] : null);
@@ -1788,7 +1883,7 @@ var ShortcodePreview = Backbone.View.extend({
 module.exports = ShortcodePreview;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],21:[function(require,module,exports){
+},{}],22:[function(require,module,exports){
 (function (global){
 var Backbone = (typeof window !== "undefined" ? window['Backbone'] : typeof global !== "undefined" ? global['Backbone'] : null),
 	insertShortcodeList = require('./insert-shortcode-list.js'),
@@ -1894,4 +1989,4 @@ var Shortcode_UI = Backbone.View.extend({
 module.exports = Shortcode_UI;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./../utils/sui.js":9,"./edit-shortcode-form.js":14,"./insert-shortcode-list.js":16,"./media-toolbar.js":18,"./search-shortcode.js":19,"./shortcode-preview.js":20}]},{},[7]);
+},{"./../utils/sui.js":10,"./edit-shortcode-form.js":15,"./insert-shortcode-list.js":17,"./media-toolbar.js":19,"./search-shortcode.js":20,"./shortcode-preview.js":21}]},{},[7]);

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -315,20 +315,27 @@ var Fetcher = (function() {
 	 * Resolves their respective promises.
 	 */
 	this.fetchAll = function() {
+		delete fetcher.timeout;
+
+		if ( 0 === fetcher.queries.length ) {
+			return;
+		}
+
 		var request = $.post( ajaxurl + '?action=bulk_do_shortcode', {
 				queries: _.pluck( fetcher.queries, 'query' )
 			}
 		);
-
-		delete fetcher.timeout;
 
 		request.done( function( response ) {
 			_.each( response.data, function( result, index ) {
 				var matchedQuery = _.findWhere( fetcher.queries, {
 					counter: parseInt( index ),
 				});
-				fetcher.queries = _.without( fetcher.queries, matchedQuery );
-				matchedQuery.promise.resolve( result );
+
+				if ( matchedQuery ) {
+					fetcher.queries = _.without( fetcher.queries, matchedQuery );
+					matchedQuery.promise.resolve( result );
+				}
 			} );
 		} );
 	};

--- a/js/src/utils/fetcher.js
+++ b/js/src/utils/fetcher.js
@@ -47,9 +47,9 @@ var Fetcher = (function() {
 		delete fetcher.timeout;
 
 		request.done( function( response ) {
-			_.each( response.data, function( result ) {
+			_.each( response.data, function( result, index ) {
 				var matchedQuery = _.findWhere( fetcher.queries, {
-					counter: parseInt( result.counter ),
+					counter: parseInt( index ),
 				});
 				fetcher.queries = _.without( fetcher.queries, matchedQuery );
 				matchedQuery.promise.resolve( result );

--- a/js/src/utils/fetcher.js
+++ b/js/src/utils/fetcher.js
@@ -27,7 +27,7 @@ var Fetcher = (function() {
 
 		if ( ! fetcher.timeout ) {
 			fetcher.timeout = setTimeout(
-				fetcher.fetchAll, 500
+				fetcher.fetchAll, 200
 			);
 		}
 		return fetchPromise;
@@ -43,6 +43,8 @@ var Fetcher = (function() {
 				queries: _.pluck( fetcher.queries, 'query' )
 			}
 		);
+
+		delete fetcher.timeout;
 
 		request.done( function( response ) {
 			_.each( response.data, function( result ) {

--- a/js/src/utils/fetcher.js
+++ b/js/src/utils/fetcher.js
@@ -1,0 +1,66 @@
+var $ = require('jquery');
+var _ = require('underscore');
+
+var Fetcher = (function() {
+	var fetcher = this;
+
+	this.counter = 0;
+	this.queries = [];
+	this.timeout = null;
+
+	/**
+	 * Add a query to the queue.
+	 *
+	 * Returns a promise that will be resolved when the query is successfully
+	 * returned.
+	 */
+	this.queueToFetch = function( query ) {
+		var fetchPromise = new $.Deferred();
+
+		query.counter = ++fetcher.counter;
+
+		fetcher.queries.push({
+			promise: fetchPromise,
+			query: query,
+			counter: query.counter
+		});
+
+		if ( ! fetcher.timeout ) {
+			fetcher.timeout = setTimeout(
+				fetcher.fetchAll, 500
+			);
+		}
+		return fetchPromise;
+	};
+
+	/**
+	 * Execute all queued queries.
+	 *
+	 * Resolves their respective promises.
+	 */
+	this.fetchAll = function() {
+		var request = $.post( ajaxurl + '?action=bulk_do_shortcode', {
+				queries: _.pluck( fetcher.queries, 'query' )
+			}
+		);
+
+		request.done( function( response ) {
+			_.each( response.data, function( result ) {
+				var matchedQuery = _.findWhere( fetcher.queries, {
+					counter: parseInt( result.counter ),
+				});
+				fetcher.queries = _.without( fetcher.queries, matchedQuery );
+				matchedQuery.promise.resolve( result );
+			} );
+		} );
+	};
+
+	// Public API methods available
+	return {
+		queueToFetch : this.queueToFetch,
+		fetchAll     : this.fetchAll
+	};
+
+})();
+
+module.exports = Fetcher;

--- a/js/src/utils/fetcher.js
+++ b/js/src/utils/fetcher.js
@@ -39,20 +39,27 @@ var Fetcher = (function() {
 	 * Resolves their respective promises.
 	 */
 	this.fetchAll = function() {
+		delete fetcher.timeout;
+
+		if ( 0 === fetcher.queries.length ) {
+			return;
+		}
+
 		var request = $.post( ajaxurl + '?action=bulk_do_shortcode', {
 				queries: _.pluck( fetcher.queries, 'query' )
 			}
 		);
-
-		delete fetcher.timeout;
 
 		request.done( function( response ) {
 			_.each( response.data, function( result, index ) {
 				var matchedQuery = _.findWhere( fetcher.queries, {
 					counter: parseInt( index ),
 				});
-				fetcher.queries = _.without( fetcher.queries, matchedQuery );
-				matchedQuery.promise.resolve( result );
+
+				if ( matchedQuery ) {
+					fetcher.queries = _.without( fetcher.queries, matchedQuery );
+					matchedQuery.promise.resolve( result );
+				}
 			} );
 		} );
 	};

--- a/js/src/utils/fetcher.js
+++ b/js/src/utils/fetcher.js
@@ -26,10 +26,9 @@ var Fetcher = (function() {
 		});
 
 		if ( ! fetcher.timeout ) {
-			fetcher.timeout = setTimeout(
-				fetcher.fetchAll, 200
-			);
+			fetcher.timeout = setTimeout( fetcher.fetchAll );
 		}
+
 		return fetchPromise;
 	};
 

--- a/js/src/utils/shortcode-view-constructor.js
+++ b/js/src/utils/shortcode-view-constructor.js
@@ -69,7 +69,7 @@ var shortcodeViewConstructor = {
 	},
 
 	delayedFetch : function() {
-		return /* this.fetching ||*/ fetcher.queueToFetch({
+		return fetcher.queueToFetch({
 			post_id: $( '#post_ID' ).val(),
 			shortcode: this.shortcodeModel.formatShortcode(),
 			nonce: shortcodeUIData.nonces.preview,

--- a/js/src/utils/shortcode-view-constructor.js
+++ b/js/src/utils/shortcode-view-constructor.js
@@ -1,6 +1,7 @@
 var sui = require('sui-utils/sui'),
-    wp = require('wp'),
-    $ = require('jquery');
+	fetcher = require('sui-utils/fetcher'),
+	wp = require('wp'),
+	$ = require('jquery');
 
 /**
  * Generic shortcode mce view constructor.
@@ -9,8 +10,24 @@ var sui = require('sui-utils/sui'),
 var shortcodeViewConstructor = {
 
 	initialize: function( options ) {
+		var self = this;
+
 		this.shortcodeModel = this.getShortcodeModel( this.shortcode );
-		this.fetch();
+		this.fetching = this.delayedFetch();
+
+		this.fetching.done( function( queryResponse ) {
+			var response = queryResponse.response;
+			if ( '' === response ) {
+				self.content = '<span class="shortcake-notice shortcake-empty">' + self.shortcodeModel.formatShortcode() + '</span>';
+			} else {
+				self.content = response;
+			}
+		}).fail( function() {
+			self.content = '<span class="shortcake-error">' + shortcodeUIData.strings.mce_view_error + '</span>';
+		} ).always( function() {
+			delete self.fetching;
+			self.render( null, true );
+		} );
 	},
 
 	/**
@@ -49,6 +66,14 @@ var shortcodeViewConstructor = {
 
 		return shortcodeModel;
 
+	},
+
+	delayedFetch : function() {
+		return /* this.fetching ||*/ fetcher.queueToFetch({
+			post_id: $( '#post_ID' ).val(),
+			shortcode: this.shortcodeModel.formatShortcode(),
+			nonce: shortcodeUIData.nonces.preview,
+		});
 	},
 
 	/**


### PR DESCRIPTION
Adds a `Fetcher` utility class to combine and bulk-send requests for
shortcode previews. Currently - until I can find some reliable events on
MCE processing to hook to - this is being done in a very naive way:
every time a request is made, it sets a half-second timeout, so that any
other requests needed can be gathered and sent together.

See #371
