### PR TITLE
Restore capability check when rendering a shortcode preview

### DIFF
--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -300,6 +300,10 @@ class Shortcode_UI {
 			define( 'SHORTCODE_UI_DOING_PREVIEW', true );
 		}
 
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return esc_html__( "Something's rotten in the state of Denmark", 'shortcode-ui' );
+		}
+
 		if ( ! empty( $post_id ) ) {
 			// @codingStandardsIgnoreStart
 			global $post;


### PR DESCRIPTION
Better safe than sorry

Removed in #480
