### PR TITLE
Add shortcode argument filters

### DIFF
--- a/shortcode-ui.php
+++ b/shortcode-ui.php
@@ -81,7 +81,7 @@ function shortcode_ui_register_for_shortcode( $shortcode_tag, $args = array() ) 
 	 *
 	 * @param array $args The configuration argument array specified in shortcode_ui_register_for_shortcode()
 	 */
-	$args = apply_filters( 'shortcode_ui_shortcode_args_' . $shortcode_tag, $args );
+	$args = apply_filters( "shortcode_ui_shortcode_args_{$shortcode_tag}", $args );
 
 	Shortcode_UI::get_instance()->register_shortcode_ui( $shortcode_tag, $args );
 }

--- a/shortcode-ui.php
+++ b/shortcode-ui.php
@@ -61,7 +61,28 @@ function shortcode_ui_load_textdomain() {
  * @return null
  */
 function shortcode_ui_register_for_shortcode( $shortcode_tag, $args = array() ) {
-	$args = apply_filters( 'shortcode_ui_shortcode_args_' . $shortcode_tag, apply_filters( 'shortcode_ui_shortcode_args', $args, $shortcode_tag ) );
+
+	/**
+	 * Filter the Shortcode UI options for all registered shortcodes.
+	 *
+	 * @since 0.6.0
+	 *
+	 * @param array $args   The configuration argument array specified in shortcode_ui_register_for_shortcode()
+	 * @param string $shortcode_tag The shortcode base.
+	 */
+	$args = apply_filters( 'shortcode_ui_shortcode_args', $args, $shortcode_tag );
+
+	/**
+	 * Filter the Shortcode UI options for a specific registered shortcode.
+	 *
+	 * This dynamic filter uses the shortcode base and thus lets you hook on the options on a specific shortcode.
+	 *
+	 * @since 0.6.0
+	 *
+	 * @param array $args   The configuration argument array specified in shortcode_ui_register_for_shortcode()
+	 */
+	$args = apply_filters( 'shortcode_ui_shortcode_args_' . $shortcode_tag, $args );
+
 	Shortcode_UI::get_instance()->register_shortcode_ui( $shortcode_tag, $args );
 }
 

--- a/shortcode-ui.php
+++ b/shortcode-ui.php
@@ -67,7 +67,7 @@ function shortcode_ui_register_for_shortcode( $shortcode_tag, $args = array() ) 
 	 *
 	 * @since 0.6.0
 	 *
-	 * @param array $args   The configuration argument array specified in shortcode_ui_register_for_shortcode()
+	 * @param array $args           The configuration argument array specified in shortcode_ui_register_for_shortcode()
 	 * @param string $shortcode_tag The shortcode base.
 	 */
 	$args = apply_filters( 'shortcode_ui_shortcode_args', $args, $shortcode_tag );
@@ -79,7 +79,7 @@ function shortcode_ui_register_for_shortcode( $shortcode_tag, $args = array() ) 
 	 *
 	 * @since 0.6.0
 	 *
-	 * @param array $args   The configuration argument array specified in shortcode_ui_register_for_shortcode()
+	 * @param array $args The configuration argument array specified in shortcode_ui_register_for_shortcode()
 	 */
 	$args = apply_filters( 'shortcode_ui_shortcode_args_' . $shortcode_tag, $args );
 

--- a/shortcode-ui.php
+++ b/shortcode-ui.php
@@ -61,7 +61,7 @@ function shortcode_ui_load_textdomain() {
  * @return null
  */
 function shortcode_ui_register_for_shortcode( $shortcode_tag, $args = array() ) {
-	$args = apply_filters('shortcode_ui_shortcode_args_' . $shortcode_tag, apply_filters('shortcode_ui_shortcode_args', $args, $shortcode_tag));
+	$args = apply_filters( 'shortcode_ui_shortcode_args_' . $shortcode_tag, apply_filters( 'shortcode_ui_shortcode_args', $args, $shortcode_tag ) );
 	Shortcode_UI::get_instance()->register_shortcode_ui( $shortcode_tag, $args );
 }
 

--- a/shortcode-ui.php
+++ b/shortcode-ui.php
@@ -61,6 +61,7 @@ function shortcode_ui_load_textdomain() {
  * @return null
  */
 function shortcode_ui_register_for_shortcode( $shortcode_tag, $args = array() ) {
+	$args = apply_filters('shortcode_ui_shortcode_args_' . $shortcode_tag, apply_filters('shortcode_ui_shortcode_args', $args, $shortcode_tag));
 	Shortcode_UI::get_instance()->register_shortcode_ui( $shortcode_tag, $args );
 }
 


### PR DESCRIPTION
Currently, there is no way to make global changes to Shortcode options through a filter. 
This PR introduces two filters:

`shortcode_ui_shortcode_args` - Passes `$args` (The Shortcode UI config arguments) and `$shortcode_tag` (The base shortcode tag)

`shortcode_ui_shortcode_args_{$shortcode_tag}`\- Dynamically named filter that lets you filter the config arguments to a specific shortcode. Passes `$args`(The Shortcode UI config arguments).

Example use:

**Add a checkbox to all Shortcode UI blocks**

``` php
add_filter('shortcode_ui_shortcode_args', function($args, $tag) {

  //Add a "Disable paddings" checkbox to all Shortcode UI modals.
  $args['attrs'][] = array(
    'label'  => esc_html__( 'Disable paddings', LRF_TD),
    'attr'   => 'disable_paddings',
    'type'   => 'checkbox',
  );

  return $args;
}, 10, 2);
```

**Add a checkbox to the shortcode [lrf_section_background_start]**

``` php
add_filter('shortcode_ui_shortcode_args_lrf_section_background_start', function($args) {

  //Add a "Disable paddings" checkbox to the shortcode [lrf_section_background_start]
  $args['attrs'][] = array(
    'label'  => esc_html__( 'Disable paddings 2', LRF_TD),
    'attr'   => 'disable_paddings 2',
    'type'   => 'checkbox',
  );

  return $args;
}, 10);
```

@danielbachhuber @goldenapples 
