### PR TITLE
Add description to post select field

### DIFF
--- a/inc/fields/class-field-post-select.php
+++ b/inc/fields/class-field-post-select.php
@@ -78,6 +78,9 @@ class Shortcode_UI_Field_Post_Select {
 			<div class="field-block shortcode-ui-field-post-select shortcode-ui-attribute-{{ data.attr }}">
 				<label for="{{ data.id }}">{{ data.label }}</label>
 				<input type="text" name="{{ data.attr }}" id="{{ data.id }}" value="{{ data.value }}" class="shortcode-ui-post-select" />
+				<# if ( typeof data.description == 'string' ) { #>
+					<p class="description">{{ data.description }}</p>
+				<# } #>
 			</div>
 		</script>
 


### PR DESCRIPTION
Post select field seems to lack a description field like all the other fields have, adding it in.

**Screenshot**
![screen shot 2015-10-05 at 12 27 33](https://cloud.githubusercontent.com/assets/1207507/10278354/ff6cabd4-6b5c-11e5-9e0e-c0762b1cef3c.png)
