### PR TITLE
Example plugin: Split UI setup into separate functions (basic and advanced)

### DIFF
--- a/dev.php
+++ b/dev.php
@@ -18,20 +18,35 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
+add_action( 'init', 'shortcode_ui_detection' );
 
-add_action( 'init', 'shortcode_ui_dev_example' );
-
-function shortcode_ui_dev_example() {
-
-	if ( ! function_exists( 'shortcode_ui_register_for_shortcode' ) ) {
-		add_action( 'admin_notices', 'shortcode_ui_dev_example_notices');
+function shortcode_ui_detection() {
+	if ( !function_exists( 'shortcode_ui_register_for_shortcode' ) ) {
+		add_action( 'admin_notices', 'shortcode_ui_dev_example_notices' );
 		return;
 	}
+}
+
+function shortcode_ui_dev_example_notices() {
+	if ( current_user_can( 'activate_plugins' ) ) {
+		echo '<div class="error message"><p>Shortcode UI plugin must be active for Shortcode UI Example plugin to function.</p></div>';
+	}
+}
+
+add_action( 'init', 'shortcode_ui_dev_minimal_example' );
+
+function shortcode_ui_dev_minimal_example() {
+
 
 	add_shortcode( 'shortcake-no-attributes', '__return_false' );
 	shortcode_ui_register_for_shortcode( 'no-attributes', array(
-		'label'        => 'Shortcake With No Attributes',
-		) );
+	    'label' => 'Shortcake With No Attributes',
+	) );
+}
+
+add_action( 'init', 'shortcode_ui_dev_advanced_example' );
+
+function shortcode_ui_dev_advanced_example() {
 
 	/**
 	 * Register your shortcode as you would normally.
@@ -45,87 +60,66 @@ function shortcode_ui_dev_example() {
 	 * and an array or args.
 	 */
 	shortcode_ui_register_for_shortcode(
-		'shortcake_dev',
+		'shortcake_dev', array(
+	    // Display label. String. Required.
+	    'label' => 'Shortcake Dev',
+	    // Icon/attachment for shortcode. Optional. src or dashicons-$icon. Defaults to carrot.
+	    'listItemImage' => 'dashicons-editor-quote',
+	    'inner_content' => array(
+		'label' => 'Quote',
+	    ),
+	    'post_type' => array( 'post' ),
+	    // Available shortcode attributes and default values. Required. Array.
+	    // Attribute model expects 'attr', 'type' and 'label'
+	    // Supported field types: text, checkbox, textarea, radio, select, email, url, number, and date.
+	    'attrs' => array(
 		array(
-
-			// Display label. String. Required.
-			'label' => 'Shortcake Dev',
-
-			// Icon/attachment for shortcode. Optional. src or dashicons-$icon. Defaults to carrot.
-			'listItemImage' => 'dashicons-editor-quote',
-
-			'inner_content' => array(
-				'label' => 'Quote',
-			),
-
-			'post_type'     => array( 'post' ),
-
-			// Available shortcode attributes and default values. Required. Array.
-			// Attribute model expects 'attr', 'type' and 'label'
-			// Supported field types: text, checkbox, textarea, radio, select, email, url, number, and date.
-			'attrs' => array(
-
-				array(
-					'label' => 'Attachment',
-					'attr'  => 'attachment',
-					'type'  => 'attachment',
-					'libraryType' => array( 'image' ),
-					'addButton'   => 'Select Image',
-					'frameTitle'  => 'Select Image',
-				),
-
-				array(
-					'label' => 'Cite',
-					'attr'  => 'source',
-					'type'  => 'text',
-					'meta' => array(
-						'placeholder' => 'Test placeholder',
-						'data-test'    => 1,
-					),
-				),
-
-				array(
-					'label'    => 'Select Page',
-					'attr'     => 'page',
-					'type'     => 'post_select',
-					'query'    => array( 'post_type' => 'page' ),
-					'multiple' => true,
-				),
-
-			),
-
+		    'label' => 'Attachment',
+		    'attr' => 'attachment',
+		    'type' => 'attachment',
+		    'libraryType' => array( 'image' ),
+		    'addButton' => 'Select Image',
+		    'frameTitle' => 'Select Image',
+		),
+		array(
+		    'label' => 'Cite',
+		    'attr' => 'source',
+		    'type' => 'text',
+		    'meta' => array(
+			'placeholder' => 'Test placeholder',
+			'data-test' => 1,
+		    ),
+		),
+		array(
+		    'label' => 'Select Page',
+		    'attr' => 'page',
+		    'type' => 'post_select',
+		    'query' => array( 'post_type' => 'page' ),
+		    'multiple' => true,
+		),
+	    ),
 		)
 	);
-
-}
-
-function shortcode_ui_dev_example_notices(){
-	if ( current_user_can( 'activate_plugins' ) ) {
-		echo '<div class="error message"><p>Shortcode UI plugin must be active for Shortcode UI Example plugin to function.</p></div>';
-	}
 }
 
 function shortcode_ui_dev_shortcode( $attr, $content = '' ) {
 
 	$attr = wp_parse_args( $attr, array(
-		'source'     => '',
-		'attachment' => 0
-	) );
+	    'source' => '',
+	    'attachment' => 0
+		) );
 
 	ob_start();
-
-?>
+	?>
 
 	<section class="pullquote" style="padding: 20px; background: rgba(0,0,0,0.1);">
-		<p style="margin:0; padding: 0;">
-			<b>Content:</b> <?php echo wpautop( wp_kses_post( $content ) ); ?></br>
-			<b>Source:</b> <?php echo esc_html( $attr['source'] ); ?></br>
-			<b>Image:</b> <?php echo wp_get_attachment_image( $attr['attachment'], array( 50, 50 ) ); ?></br>
-		</p>
+	    <p style="margin:0; padding: 0;">
+		<b>Content:</b> <?php echo wpautop( wp_kses_post( $content ) ); ?></br>
+		<b>Source:</b> <?php echo esc_html( $attr[ 'source' ] ); ?></br>
+		<b>Image:</b> <?php echo wp_get_attachment_image( $attr[ 'attachment' ], array( 50, 50 ) ); ?></br>
+	    </p>
 	</section>
 
-<?php
-
+	<?php
 	return ob_get_clean();
-
 }

--- a/dev.php
+++ b/dev.php
@@ -61,33 +61,31 @@ function shortcode_ui_dev_advanced_example() {
 	 */
 	shortcode_ui_register_for_shortcode(
 		'shortcake_dev', array(
-	    // Display label. String. Required.
-	    'label' => 'Shortcake Dev',
-	    // Icon/attachment for shortcode. Optional. src or dashicons-$icon. Defaults to carrot.
-	    'listItemImage' => 'dashicons-editor-quote',
+	    'label' => 'Shortcake Dev', // Display label. String. Required.
+	    'listItemImage' => 'dashicons-editor-quote', // Icon/attachment for shortcode. Optional. src or dashicons-$icon. Defaults to carrot.
 	    'inner_content' => array(
 		'label' => 'Quote',
 	    ),
-	    'post_type' => array( 'post' ),
+	    'post_type' => array( 'post' ), //Post type support
 	    // Available shortcode attributes and default values. Required. Array.
 	    // Attribute model expects 'attr', 'type' and 'label'
 	    // Supported field types: text, checkbox, textarea, radio, select, email, url, number, and date.
 	    'attrs' => array(
 		array(
-		    'label' => 'Attachment',
-		    'attr' => 'attachment',
+		    'label' => __( 'Attachment', 'your-text-domain' ), // Field label
+		    'attr' => 'attachment', // Field type
 		    'type' => 'attachment',
-		    'libraryType' => array( 'image' ),
-		    'addButton' => 'Select Image',
-		    'frameTitle' => 'Select Image',
+		    'libraryType' => array( 'image' ), // Media type to insert
+		    'addButton' => __( 'Select Image', 'your-text-domain' ), // Button text that opens Media Library
+		    'frameTitle' => __( 'Select Image', 'your-text-domain ' ), // Media Library frame title
 		),
 		array(
-		    'label' => 'Cite',
+		    'label' => __( 'Citation Source', 'your-text-domain' ),
 		    'attr' => 'source',
 		    'type' => 'text',
-		    'meta' => array(
+		    'meta' => array( // Holds custom field attributes.
 			'placeholder' => 'Test placeholder',
-			'data-test' => 1,
+			'data-test' => 1, // Custom data attribute
 		    ),
 		),
 		array(
@@ -104,6 +102,7 @@ function shortcode_ui_dev_advanced_example() {
 
 function shortcode_ui_dev_shortcode( $attr, $content = '' ) {
 
+	//Parse the attribute of the shortcode
 	$attr = wp_parse_args( $attr, array(
 	    'source' => '',
 	    'attachment' => 0


### PR DESCRIPTION
I've added the support for few of the points in that ticket #395 
