### PR TITLE
Run autop to avoid multiline inner_content wrapping

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -141,6 +141,7 @@ module.exports = function( grunt ) {
 						'js-tests/vendor/wp-shortcode.js',
 						'js-tests/vendor/wp-util.js',
 						'js-tests/vendor/wp-editors.js',
+						'js-tests/vendor/editor.js',
 						'js-tests/vendor/mock-ajax.js',
 					],
 				}

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -534,6 +534,11 @@ Shortcode = Backbone.Model.extend({
 			content = this.get( 'inner_content_backup' );
 		}
 
+		//Run autop before shooting into view
+		if( content ) {
+			content = window.wp.editor.autop( content );
+		}
+
 		if ( attrs.length > 0 ) {
 			template = "[{{ shortcode }} {{ attributes }}]";
 		} else {

--- a/js-tests/vendor/editor.js
+++ b/js-tests/vendor/editor.js
@@ -1,0 +1,370 @@
+
+( function( $ ) {
+	function SwitchEditors() {
+		var tinymce, $$,
+			exports = {};
+
+		function init() {
+			if ( ! tinymce && window.tinymce ) {
+				tinymce = window.tinymce;
+				$$ = tinymce.$;
+
+				$$( document ).on( 'click', function( event ) {
+					var id, mode,
+						target = $$( event.target );
+
+					if ( target.hasClass( 'wp-switch-editor' ) ) {
+						id = target.attr( 'data-wp-editor-id' );
+						mode = target.hasClass( 'switch-tmce' ) ? 'tmce' : 'html';
+						switchEditor( id, mode );
+					}
+				});
+			}
+		}
+
+		function getToolbarHeight( editor ) {
+			var node = $$( '.mce-toolbar-grp', editor.getContainer() )[0],
+				height = node && node.clientHeight;
+
+			if ( height && height > 10 && height < 200 ) {
+				return parseInt( height, 10 );
+			}
+
+			return 30;
+		}
+
+		function switchEditor( id, mode ) {
+			id = id || 'content';
+			mode = mode || 'toggle';
+
+			var editorHeight, toolbarHeight, iframe,
+				editor = tinymce.get( id ),
+				wrap = $$( '#wp-' + id + '-wrap' ),
+				$textarea = $$( '#' + id ),
+				textarea = $textarea[0];
+
+			if ( 'toggle' === mode ) {
+				if ( editor && ! editor.isHidden() ) {
+					mode = 'html';
+				} else {
+					mode = 'tmce';
+				}
+			}
+
+			if ( 'tmce' === mode || 'tinymce' === mode ) {
+				if ( editor && ! editor.isHidden() ) {
+					return false;
+				}
+
+				if ( typeof( window.QTags ) !== 'undefined' ) {
+					window.QTags.closeAllTags( id );
+				}
+
+				editorHeight = parseInt( textarea.style.height, 10 ) || 0;
+
+				if ( editor ) {
+					editor.show();
+
+					// No point resizing the iframe in iOS
+					if ( ! tinymce.Env.iOS && editorHeight ) {
+						toolbarHeight = getToolbarHeight( editor );
+						editorHeight = editorHeight - toolbarHeight + 14;
+
+						// height cannot be under 50 or over 5000
+						if ( editorHeight > 50 && editorHeight < 5000 ) {
+							editor.theme.resizeTo( null, editorHeight );
+						}
+					}
+				} else {
+					tinymce.init( window.tinyMCEPreInit.mceInit[id] );
+				}
+
+				wrap.removeClass( 'html-active' ).addClass( 'tmce-active' );
+				$textarea.attr( 'aria-hidden', true );
+				window.setUserSetting( 'editor', 'tinymce' );
+
+			} else if ( 'html' === mode ) {
+				if ( editor && editor.isHidden() ) {
+					return false;
+				}
+
+				if ( editor ) {
+					if ( ! tinymce.Env.iOS ) {
+						iframe = editor.iframeElement;
+						editorHeight = iframe ? parseInt( iframe.style.height, 10 ) : 0;
+
+						if ( editorHeight ) {
+							toolbarHeight = getToolbarHeight( editor );
+							editorHeight = editorHeight + toolbarHeight - 14;
+
+							// height cannot be under 50 or over 5000
+							if ( editorHeight > 50 && editorHeight < 5000 ) {
+								textarea.style.height = editorHeight + 'px';
+							}
+						}
+					}
+
+					editor.hide();
+				} else {
+					// The TinyMCE instance doesn't exist, show the textarea
+					$textarea.css({ 'display': '', 'visibility': '' });
+				}
+
+				wrap.removeClass( 'tmce-active' ).addClass( 'html-active' );
+				$textarea.attr( 'aria-hidden', false );
+				window.setUserSetting( 'editor', 'html' );
+			}
+		}
+
+		// Replace paragraphs with double line breaks
+		function removep( html ) {
+			var blocklist = 'blockquote|ul|ol|li|table|thead|tbody|tfoot|tr|th|td|h[1-6]|fieldset',
+				blocklist1 = blocklist + '|div|p',
+				blocklist2 = blocklist + '|pre',
+				preserve_linebreaks = false,
+				preserve_br = false;
+
+			if ( ! html ) {
+				return '';
+			}
+
+			// Protect pre|script tags
+			if ( html.indexOf( '<pre' ) !== -1 || html.indexOf( '<script' ) !== -1 ) {
+				preserve_linebreaks = true;
+				html = html.replace( /<(pre|script)[^>]*>[\s\S]+?<\/\1>/g, function( a ) {
+					a = a.replace( /<br ?\/?>(\r\n|\n)?/g, '<wp-line-break>' );
+					a = a.replace( /<\/?p( [^>]*)?>(\r\n|\n)?/g, '<wp-line-break>' );
+					return a.replace( /\r?\n/g, '<wp-line-break>' );
+				});
+			}
+
+			// keep <br> tags inside captions and remove line breaks
+			if ( html.indexOf( '[caption' ) !== -1 ) {
+				preserve_br = true;
+				html = html.replace( /\[caption[\s\S]+?\[\/caption\]/g, function( a ) {
+					return a.replace( /<br([^>]*)>/g, '<wp-temp-br$1>' ).replace( /[\r\n\t]+/, '' );
+				});
+			}
+
+			// Pretty it up for the source editor
+			html = html.replace( new RegExp( '\\s*</(' + blocklist1 + ')>\\s*', 'g' ), '</$1>\n' );
+			html = html.replace( new RegExp( '\\s*<((?:' + blocklist1 + ')(?: [^>]*)?)>', 'g' ), '\n<$1>' );
+
+			// Mark </p> if it has any attributes.
+			html = html.replace( /(<p [^>]+>.*?)<\/p>/g, '$1</p#>' );
+
+			// Separate <div> containing <p>
+			html = html.replace( /<div( [^>]*)?>\s*<p>/gi, '<div$1>\n\n' );
+
+			// Remove <p> and <br />
+			html = html.replace( /\s*<p>/gi, '' );
+			html = html.replace( /\s*<\/p>\s*/gi, '\n\n' );
+			html = html.replace( /\n[\s\u00a0]+\n/g, '\n\n' );
+			html = html.replace( /\s*<br ?\/?>\s*/gi, '\n' );
+
+			// Fix some block element newline issues
+			html = html.replace( /\s*<div/g, '\n<div' );
+			html = html.replace( /<\/div>\s*/g, '</div>\n' );
+			html = html.replace( /\s*\[caption([^\[]+)\[\/caption\]\s*/gi, '\n\n[caption$1[/caption]\n\n' );
+			html = html.replace( /caption\]\n\n+\[caption/g, 'caption]\n\n[caption' );
+
+			html = html.replace( new RegExp('\\s*<((?:' + blocklist2 + ')(?: [^>]*)?)\\s*>', 'g' ), '\n<$1>' );
+			html = html.replace( new RegExp('\\s*</(' + blocklist2 + ')>\\s*', 'g' ), '</$1>\n' );
+			html = html.replace( /<li([^>]*)>/g, '\t<li$1>' );
+
+			if ( html.indexOf( '<option' ) !== -1 ) {
+				html = html.replace( /\s*<option/g, '\n<option' );
+				html = html.replace( /\s*<\/select>/g, '\n</select>' );
+			}
+
+			if ( html.indexOf( '<hr' ) !== -1 ) {
+				html = html.replace( /\s*<hr( [^>]*)?>\s*/g, '\n\n<hr$1>\n\n' );
+			}
+
+			if ( html.indexOf( '<object' ) !== -1 ) {
+				html = html.replace( /<object[\s\S]+?<\/object>/g, function( a ) {
+					return a.replace( /[\r\n]+/g, '' );
+				});
+			}
+
+			// Unmark special paragraph closing tags
+			html = html.replace( /<\/p#>/g, '</p>\n' );
+			html = html.replace( /\s*(<p [^>]+>[\s\S]*?<\/p>)/g, '\n$1' );
+
+			// Trim whitespace
+			html = html.replace( /^\s+/, '' );
+			html = html.replace( /[\s\u00a0]+$/, '' );
+
+			// put back the line breaks in pre|script
+			if ( preserve_linebreaks ) {
+				html = html.replace( /<wp-line-break>/g, '\n' );
+			}
+
+			// and the <br> tags in captions
+			if ( preserve_br ) {
+				html = html.replace( /<wp-temp-br([^>]*)>/g, '<br$1>' );
+			}
+
+			return html;
+		}
+
+		// Similar to `wpautop()` in formatting.php
+		function autop( text ) {
+			var preserve_linebreaks = false,
+				preserve_br = false,
+				blocklist = 'table|thead|tfoot|caption|col|colgroup|tbody|tr|td|th|div|dl|dd|dt|ul|ol|li|pre' +
+					'|form|map|area|blockquote|address|math|style|p|h[1-6]|hr|fieldset|legend|section' +
+					'|article|aside|hgroup|header|footer|nav|figure|figcaption|details|menu|summary';
+
+			// Normalize line breaks
+			text = text.replace( /\r\n|\r/g, '\n' );
+
+			if ( text.indexOf( '\n' ) === -1 ) {
+				return text;
+			}
+
+			if ( text.indexOf( '<object' ) !== -1 ) {
+				text = text.replace( /<object[\s\S]+?<\/object>/g, function( a ) {
+					return a.replace( /\n+/g, '' );
+				});
+			}
+
+			text = text.replace( /<[^<>]+>/g, function( a ) {
+				return a.replace( /[\n\t ]+/g, ' ' );
+			});
+
+			// Protect pre|script tags
+			if ( text.indexOf( '<pre' ) !== -1 || text.indexOf( '<script' ) !== -1 ) {
+				preserve_linebreaks = true;
+				text = text.replace( /<(pre|script)[^>]*>[\s\S]+?<\/\1>/g, function( a ) {
+					return a.replace( /\n/g, '<wp-line-break>' );
+				});
+			}
+
+			// keep <br> tags inside captions and convert line breaks
+			if ( text.indexOf( '[caption' ) !== -1 ) {
+				preserve_br = true;
+				text = text.replace( /\[caption[\s\S]+?\[\/caption\]/g, function( a ) {
+					// keep existing <br>
+					a = a.replace( /<br([^>]*)>/g, '<wp-temp-br$1>' );
+					// no line breaks inside HTML tags
+					a = a.replace( /<[^<>]+>/g, function( b ) {
+						return b.replace( /[\n\t ]+/, ' ' );
+					});
+					// convert remaining line breaks to <br>
+					return a.replace( /\s*\n\s*/g, '<wp-temp-br />' );
+				});
+			}
+
+			text = text + '\n\n';
+			text = text.replace( /<br \/>\s*<br \/>/gi, '\n\n' );
+			text = text.replace( new RegExp( '(<(?:' + blocklist + ')(?: [^>]*)?>)', 'gi' ), '\n$1' );
+			text = text.replace( new RegExp( '(</(?:' + blocklist + ')>)', 'gi' ), '$1\n\n' );
+			text = text.replace( /<hr( [^>]*)?>/gi, '<hr$1>\n\n' ); // hr is self closing block element
+			text = text.replace( /\s*<option/gi, '<option' ); // No <p> or <br> around <option>
+			text = text.replace( /<\/option>\s*/gi, '</option>' );
+			text = text.replace( /\n\s*\n+/g, '\n\n' );
+			text = text.replace( /([\s\S]+?)\n\n/g, '<p>$1</p>\n' );
+			text = text.replace( /<p>\s*?<\/p>/gi, '');
+			text = text.replace( new RegExp( '<p>\\s*(</?(?:' + blocklist + ')(?: [^>]*)?>)\\s*</p>', 'gi' ), '$1' );
+			text = text.replace( /<p>(<li.+?)<\/p>/gi, '$1');
+			text = text.replace( /<p>\s*<blockquote([^>]*)>/gi, '<blockquote$1><p>');
+			text = text.replace( /<\/blockquote>\s*<\/p>/gi, '</p></blockquote>');
+			text = text.replace( new RegExp( '<p>\\s*(</?(?:' + blocklist + ')(?: [^>]*)?>)', 'gi' ), '$1' );
+			text = text.replace( new RegExp( '(</?(?:' + blocklist + ')(?: [^>]*)?>)\\s*</p>', 'gi' ), '$1' );
+
+			// Remove redundant spaces and line breaks after existing <br /> tags
+			text = text.replace( /(<br[^>]*>)\s*\n/gi, '$1' );
+
+			// Create <br /> from the remaining line breaks
+			text = text.replace( /\s*\n/g, '<br />\n');
+
+			text = text.replace( new RegExp( '(</?(?:' + blocklist + ')[^>]*>)\\s*<br />', 'gi' ), '$1' );
+			text = text.replace( /<br \/>(\s*<\/?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)>)/gi, '$1' );
+			text = text.replace( /(?:<p>|<br ?\/?>)*\s*\[caption([^\[]+)\[\/caption\]\s*(?:<\/p>|<br ?\/?>)*/gi, '[caption$1[/caption]' );
+
+			text = text.replace( /(<(?:div|th|td|form|fieldset|dd)[^>]*>)(.*?)<\/p>/g, function( a, b, c ) {
+				if ( c.match( /<p( [^>]*)?>/ ) ) {
+					return a;
+				}
+
+				return b + '<p>' + c + '</p>';
+			});
+
+			// put back the line breaks in pre|script
+			if ( preserve_linebreaks ) {
+				text = text.replace( /<wp-line-break>/g, '\n' );
+			}
+
+			if ( preserve_br ) {
+				text = text.replace( /<wp-temp-br([^>]*)>/g, '<br$1>' );
+			}
+
+			return text;
+		}
+
+		// Add old events
+		function pre_wpautop( html ) {
+			var obj = { o: exports, data: html, unfiltered: html };
+
+			if ( $ ) {
+				$( 'body' ).trigger( 'beforePreWpautop', [ obj ] );
+			}
+
+			obj.data = removep( obj.data );
+
+			if ( $ ) {
+				$( 'body' ).trigger( 'afterPreWpautop', [ obj ] );
+			}
+
+			return obj.data;
+		}
+
+		function wpautop( text ) {
+			var obj = { o: exports, data: text, unfiltered: text };
+
+			if ( $ ) {
+				$( 'body' ).trigger( 'beforeWpautop', [ obj ] );
+			}
+
+			obj.data = autop( obj.data );
+
+			if ( $ ) {
+				$( 'body' ).trigger( 'afterWpautop', [ obj ] );
+			}
+
+			return obj.data;
+		}
+
+		if ( $ ) {
+			$( document ).ready( init );
+		} else if ( document.addEventListener ) {
+			document.addEventListener( 'DOMContentLoaded', init, false );
+			window.addEventListener( 'load', init, false );
+		} else if ( window.attachEvent ) {
+			window.attachEvent( 'onload', init );
+			document.attachEvent( 'onreadystatechange', function() {
+				if ( 'complete' === document.readyState ) {
+					init();
+				}
+			} );
+		}
+
+		window.wp = window.wp || {};
+		window.wp.editor = window.wp.editor || {};
+		window.wp.editor.autop = wpautop;
+		window.wp.editor.removep = pre_wpautop;
+
+		exports = {
+			go: switchEditor,
+			wpautop: wpautop,
+			pre_wpautop: pre_wpautop,
+			_wp_Autop: autop,
+			_wp_Nop: removep
+		};
+
+		return exports;
+	}
+
+	window.switchEditors = new SwitchEditors();
+}( window.jQuery ));

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -219,6 +219,11 @@ Shortcode = Backbone.Model.extend({
 			content = this.get( 'inner_content_backup' );
 		}
 
+		//Run autop before shooting into view
+		if( content ) {
+			content = window.wp.editor.autop( content );
+		}
+
 		if ( attrs.length > 0 ) {
 			template = "[{{ shortcode }} {{ attributes }}]";
 		} else {

--- a/js/src/models/shortcode.js
+++ b/js/src/models/shortcode.js
@@ -87,6 +87,11 @@ Shortcode = Backbone.Model.extend({
 			content = this.get( 'inner_content_backup' );
 		}
 
+		//Run autop before shooting into view
+		if( content ) {
+			content = window.wp.editor.autop( content );
+		}
+
 		if ( attrs.length > 0 ) {
 			template = "[{{ shortcode }} {{ attributes }}]";
 		} else {


### PR DESCRIPTION
If you use inner_content, there is a problem where multi-line entries get truncated into a single line after you press "Update" in the Shortcake modal. (initial load and toggling between text/visual work fine)

This pull request uses `autop()` before inserting the content into the editor. We already run `unautop()` before populating the edit modal so this appears to have no ill effects and all tests pass.

2nd opinion, @danielbachhuber @goldenapples ?

Example of problem before the patch:
![screencast 2015-10-06 16-30-32](https://cloud.githubusercontent.com/assets/1207507/10312584/17e5a6ee-6c4c-11e5-8147-86cf6abc2b36.gif)
