### PR TITLE
Use `load_textdomain` instead of `load_plugin_textdomain()`

### DIFF
--- a/shortcode-ui.php
+++ b/shortcode-ui.php
@@ -50,7 +50,13 @@ function shortcode_ui_init() {
  * @return null
  */
 function shortcode_ui_load_textdomain() {
-	load_plugin_textdomain( 'shortcode-ui', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
+	// Don't use load_plugin_textdomain because it doesn't support non-standard directories
+	// See https://core.trac.wordpress.org/ticket/23794
+	$locale = get_locale();
+	$domain = 'shortcode-ui';
+	$locale = apply_filters( 'plugin_locale', $locale, $domain );
+	$mofile = dirname( __FILE__ ) . '/languages/' . $domain . '-' . $locale . '.mo';
+	load_textdomain( $domain, $mofile );
 }
 
 /**

--- a/shortcode-ui.php
+++ b/shortcode-ui.php
@@ -55,7 +55,15 @@ function shortcode_ui_load_textdomain() {
 	$locale = get_locale();
 	$domain = 'shortcode-ui';
 	$locale = apply_filters( 'plugin_locale', $locale, $domain );
-	$mofile = dirname( __FILE__ ) . '/languages/' . $domain . '-' . $locale . '.mo';
+	$path = dirname( __FILE__ ) . '/languages';
+	// Load the textdomain according to the plugin first
+	$mofile = $domain . '-' . $locale . '.mo';
+	if ( $loaded = load_textdomain( $domain, $path . '/'. $mofile ) ) {
+		return;
+	}
+
+	// Otherwise, load from the languages directory
+	$mofile = WP_LANG_DIR . '/plugins/' . $mofile;
 	load_textdomain( $domain, $mofile );
 }
 


### PR DESCRIPTION
The latter doesn't work when the plugin is installed in non-standard locations.
