### PR TITLE
Bind to `input` event rather than `keyup`

### DIFF
--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -1274,16 +1274,9 @@ var editAttributeField = Backbone.View.extend( {
 	tagName: "div",
 
 	events: {
-		'keyup  input[type="text"]':   'inputChanged',
-		'keyup  textarea':             'inputChanged',
-		'change select':               'inputChanged',
-		'change input[type=checkbox]': 'inputChanged',
-		'change input[type=radio]':    'inputChanged',
-		'change input[type=email]':    'inputChanged',
-		'change input[type=number]':   'inputChanged',
-		'change input[type=date]':     'inputChanged',
-		'change input[type=url]':      'inputChanged',
-		'input input[type=range]':     'inputChanged',
+		'input  input':    'inputChanged',
+		'input  textarea': 'inputChanged',
+		'change select':   'inputChanged',
 	},
 
 	render: function() {

--- a/js/src/views/edit-attribute-field.js
+++ b/js/src/views/edit-attribute-field.js
@@ -7,16 +7,9 @@ var editAttributeField = Backbone.View.extend( {
 	tagName: "div",
 
 	events: {
-		'keyup  input[type="text"]':   'inputChanged',
-		'keyup  textarea':             'inputChanged',
-		'change select':               'inputChanged',
-		'change input[type=checkbox]': 'inputChanged',
-		'change input[type=radio]':    'inputChanged',
-		'change input[type=email]':    'inputChanged',
-		'change input[type=number]':   'inputChanged',
-		'change input[type=date]':     'inputChanged',
-		'change input[type=url]':      'inputChanged',
-		'input input[type=range]':     'inputChanged',
+		'input  input':    'inputChanged',
+		'input  textarea': 'inputChanged',
+		'change select':   'inputChanged',
 	},
 
 	render: function() {


### PR DESCRIPTION
For all attribute fields whose type is `input` or `textarea`, binding to
the `input` event gives a much more reliable indicator of when the
field's value has changed. This is fired every time the input's value
changes - including paste events, rather than only when it's changed by
actually typing into the field.

See #515 for an example of the behaviour this is intended to fix.
