### PR TITLE
Fixed undefined property `utils`

### DIFF
--- a/js/src/utils/sui.js
+++ b/js/src/utils/sui.js
@@ -4,6 +4,7 @@ window.Shortcode_UI = window.Shortcode_UI || {
 	shortcodes: new Shortcodes(),
 	views: {},
 	controllers: {},
+	utils: {}
 };
 
 module.exports = window.Shortcode_UI;


### PR DESCRIPTION
`sui.utils` was undefined when setting `module.exports = sui.utils.shortcodeViewConstructor = shortcodeViewConstructor;` see #525 
