### PR TITLE
Always persist unregistered shortcode attributes and inner content

### DIFF
--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -198,6 +198,23 @@ describe( 'Shortcode View Constructor', function(){
 		var shortcode = ShortcodeViewConstructor.parseShortcodeString( '[no_custom_attribute foo="bar" bar="banana"]' );
 		var _shortcode = $.extend( true, {}, shortcode );
 		expect( _shortcode.formatShortcode() ).toEqual( '[no_custom_attribute foo="bar" bar="banana"]' );
+		ShortcodeViewConstructor.shortcode = {
+			'type' : 'single',
+			'tag' : 'no_custom_attribute',
+			'attrs' : {
+				'named' : {
+					'foo' : 'bar',
+					'bar' : 'banana',
+				},
+				'numeric' : [],
+			},
+		};
+		var ShortcodeViewConstructorWithoutFetch = ShortcodeViewConstructor;
+		ShortcodeViewConstructorWithoutFetch.delayedFetch = function() {
+			return new $.Deferred();
+		}
+		ShortcodeViewConstructor.initialize();
+		expect( ShortcodeViewConstructor.shortcodeModel.formatShortcode() ).toEqual( '[no_custom_attribute foo="bar" bar="banana"]' );
 	});
 
 	it( 'Reverses the effect of core adding wpautop to shortcode inner content', function(){

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -194,7 +194,7 @@ describe( 'Shortcode View Constructor', function(){
 		var ShortcodeViewConstructorWithoutFetch = ShortcodeViewConstructor;
 		ShortcodeViewConstructorWithoutFetch.delayedFetch = function() {
 			return new $.Deferred();
-		}
+		};
 		ShortcodeViewConstructor.initialize();
 		expect( ShortcodeViewConstructor.shortcodeModel.formatShortcode() ).toEqual( '[no_inner_content foo="bar"]burrito[/no_inner_content]' );
 	});
@@ -229,7 +229,7 @@ describe( 'Shortcode View Constructor', function(){
 		var ShortcodeViewConstructorWithoutFetch = ShortcodeViewConstructor;
 		ShortcodeViewConstructorWithoutFetch.delayedFetch = function() {
 			return new $.Deferred();
-		}
+		};
 		ShortcodeViewConstructor.initialize();
 		expect( ShortcodeViewConstructor.shortcodeModel.formatShortcode() ).toEqual( '[no_custom_attribute foo="bar" bar="banana"]' );
 	});

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -884,6 +884,9 @@ var shortcodeViewConstructor = {
 			value = attributes.named[ key ];
 			attr  = currentShortcode.get( 'attrs' ).findWhere({ attr: key });
 
+			// Reverse the effects of wpautop: https://core.trac.wordpress.org/ticket/34329
+			value = this.unAutoP( value );
+
 			if ( attr && attr.get('encode') ) {
 				value = decodeURIComponent( value );
 			}
@@ -899,10 +902,12 @@ var shortcodeViewConstructor = {
 
 		if ( options.content ) {
 			var inner_content = currentShortcode.get( 'inner_content' );
+			// Reverse the effects of wpautop: https://core.trac.wordpress.org/ticket/34329
+			options.content = this.unAutoP( options.content );
 			if ( inner_content ) {
-				inner_content.set( 'value', this.unAutoP( options.content ) );
+				inner_content.set( 'value', options.content );
 			} else {
-				currentShortcode.set( 'inner_content_backup', this.unAutoP( options.content ) );
+				currentShortcode.set( 'inner_content_backup', options.content );
 			}
 		}
 

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -180,6 +180,23 @@ describe( 'Shortcode View Constructor', function(){
 		var shortcode = ShortcodeViewConstructor.parseShortcodeString( '[no_inner_content foo="bar"]burrito[/no_inner_content]' );
 		var _shortcode = $.extend( true, {}, shortcode );
 		expect( _shortcode.formatShortcode() ).toEqual( '[no_inner_content foo="bar"]burrito[/no_inner_content]' );
+		ShortcodeViewConstructor.shortcode = {
+			'type' : 'single',
+			'tag' : 'no_inner_content',
+			'attrs' : {
+				'named' : {
+					'foo' : 'bar',
+				},
+				'numeric' : [],
+			},
+			'content' : 'burrito'
+		};
+		var ShortcodeViewConstructorWithoutFetch = ShortcodeViewConstructor;
+		ShortcodeViewConstructorWithoutFetch.delayedFetch = function() {
+			return new $.Deferred();
+		}
+		ShortcodeViewConstructor.initialize();
+		expect( ShortcodeViewConstructor.shortcodeModel.formatShortcode() ).toEqual( '[no_inner_content foo="bar"]burrito[/no_inner_content]' );
 	});
 
 	it( 'Persists custom attribute when parsing a shortcode without the attribute defined in UI', function() {

--- a/js-tests/src/shortcodeViewConstructorSpec.js
+++ b/js-tests/src/shortcodeViewConstructorSpec.js
@@ -23,6 +23,23 @@ describe( 'Shortcode View Constructor', function(){
 		var shortcode = ShortcodeViewConstructor.parseShortcodeString( '[no_inner_content foo="bar"]burrito[/no_inner_content]' );
 		var _shortcode = $.extend( true, {}, shortcode );
 		expect( _shortcode.formatShortcode() ).toEqual( '[no_inner_content foo="bar"]burrito[/no_inner_content]' );
+		ShortcodeViewConstructor.shortcode = {
+			'type' : 'single',
+			'tag' : 'no_inner_content',
+			'attrs' : {
+				'named' : {
+					'foo' : 'bar',
+				},
+				'numeric' : [],
+			},
+			'content' : 'burrito'
+		};
+		var ShortcodeViewConstructorWithoutFetch = ShortcodeViewConstructor;
+		ShortcodeViewConstructorWithoutFetch.delayedFetch = function() {
+			return new $.Deferred();
+		}
+		ShortcodeViewConstructor.initialize();
+		expect( ShortcodeViewConstructor.shortcodeModel.formatShortcode() ).toEqual( '[no_inner_content foo="bar"]burrito[/no_inner_content]' );
 	});
 
 	it( 'Persists custom attribute when parsing a shortcode without the attribute defined in UI', function() {

--- a/js-tests/src/shortcodeViewConstructorSpec.js
+++ b/js-tests/src/shortcodeViewConstructorSpec.js
@@ -41,6 +41,23 @@ describe( 'Shortcode View Constructor', function(){
 		var shortcode = ShortcodeViewConstructor.parseShortcodeString( '[no_custom_attribute foo="bar" bar="banana"]' );
 		var _shortcode = $.extend( true, {}, shortcode );
 		expect( _shortcode.formatShortcode() ).toEqual( '[no_custom_attribute foo="bar" bar="banana"]' );
+		ShortcodeViewConstructor.shortcode = {
+			'type' : 'single',
+			'tag' : 'no_custom_attribute',
+			'attrs' : {
+				'named' : {
+					'foo' : 'bar',
+					'bar' : 'banana',
+				},
+				'numeric' : [],
+			},
+		};
+		var ShortcodeViewConstructorWithoutFetch = ShortcodeViewConstructor;
+		ShortcodeViewConstructorWithoutFetch.delayedFetch = function() {
+			return new $.Deferred();
+		}
+		ShortcodeViewConstructor.initialize();
+		expect( ShortcodeViewConstructor.shortcodeModel.formatShortcode() ).toEqual( '[no_custom_attribute foo="bar" bar="banana"]' );
 	});
 
 	it( 'Reverses the effect of core adding wpautop to shortcode inner content', function(){

--- a/js-tests/src/shortcodeViewConstructorSpec.js
+++ b/js-tests/src/shortcodeViewConstructorSpec.js
@@ -37,7 +37,7 @@ describe( 'Shortcode View Constructor', function(){
 		var ShortcodeViewConstructorWithoutFetch = ShortcodeViewConstructor;
 		ShortcodeViewConstructorWithoutFetch.delayedFetch = function() {
 			return new $.Deferred();
-		}
+		};
 		ShortcodeViewConstructor.initialize();
 		expect( ShortcodeViewConstructor.shortcodeModel.formatShortcode() ).toEqual( '[no_inner_content foo="bar"]burrito[/no_inner_content]' );
 	});
@@ -72,7 +72,7 @@ describe( 'Shortcode View Constructor', function(){
 		var ShortcodeViewConstructorWithoutFetch = ShortcodeViewConstructor;
 		ShortcodeViewConstructorWithoutFetch.delayedFetch = function() {
 			return new $.Deferred();
-		}
+		};
 		ShortcodeViewConstructor.initialize();
 		expect( ShortcodeViewConstructor.shortcodeModel.formatShortcode() ).toEqual( '[no_custom_attribute foo="bar" bar="banana"]' );
 	});

--- a/js-tests/src/shortcodeViewConstructorSpec.js
+++ b/js-tests/src/shortcodeViewConstructorSpec.js
@@ -82,6 +82,10 @@ describe( 'Shortcode View Constructor', function(){
 			tag: 'pullquote',
 			content: 'This quote has</p>\n<p>Multiple line breaks two</p>\n<p>Test one',
 			type: 'closed',
+			attrs: {
+				named: {},
+				numeric: [],
+			}
 		};
 		var data = {
 			label: 'Pullquote',
@@ -102,6 +106,7 @@ describe( 'Shortcode View Constructor', function(){
 				},
 			},
 			type: 'single',
+			content: null,
 		};
 		var data = {
 			label: 'Pullquote',

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -478,6 +478,9 @@ var shortcodeViewConstructor = {
 			value = attributes.named[ key ];
 			attr  = currentShortcode.get( 'attrs' ).findWhere({ attr: key });
 
+			// Reverse the effects of wpautop: https://core.trac.wordpress.org/ticket/34329
+			value = this.unAutoP( value );
+
 			if ( attr && attr.get('encode') ) {
 				value = decodeURIComponent( value );
 			}
@@ -493,10 +496,12 @@ var shortcodeViewConstructor = {
 
 		if ( options.content ) {
 			var inner_content = currentShortcode.get( 'inner_content' );
+			// Reverse the effects of wpautop: https://core.trac.wordpress.org/ticket/34329
+			options.content = this.unAutoP( options.content );
 			if ( inner_content ) {
-				inner_content.set( 'value', this.unAutoP( options.content ) );
+				inner_content.set( 'value', options.content );
 			} else {
-				currentShortcode.set( 'inner_content_backup', this.unAutoP( options.content ) );
+				currentShortcode.set( 'inner_content_backup', options.content );
 			}
 		}
 

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -454,11 +454,10 @@ var shortcodeViewConstructor = {
 	 * values.
 	 *
 	 * @this {Shortcode}
-	 * @param {Object} options Options
+	 * @param {Object} options Options formatted as wp.shortcode.
 	 */
 	getShortcodeModel: function( options ) {
-		var shortcodeModel,
-			self = this;
+		var shortcodeModel;
 
 		shortcodeModel = sui.shortcodes.findWhere( { shortcode_tag: options.tag } );
 
@@ -466,38 +465,42 @@ var shortcodeViewConstructor = {
 			return;
 		}
 
-		shortcodeModel = shortcodeModel.clone();
+		currentShortcode = shortcodeModel.clone();
 
-		shortcodeModel.get('attrs').each( function( attr ) {
+		var attributes_backup = {};
+		var attributes = options.attrs;
+		for ( var key in attributes.named ) {
 
-			// Verify value exists for attribute.
-			if ( ! ( attr.get('attr') in options.attrs.named ) ) {
-				return;
+			if ( ! attributes.named.hasOwnProperty( key ) ) {
+				continue;
 			}
 
-			var value = options.attrs.named[ attr.get('attr') ];
+			value = attributes.named[ key ];
+			attr  = currentShortcode.get( 'attrs' ).findWhere({ attr: key });
 
-			// Reverse the effects of wpautop: https://core.trac.wordpress.org/ticket/34329
-			value = self.unAutoP( value );
-
-			// Maybe decode value.
-			if ( attr.get('encode') ) {
+			if ( attr && attr.get('encode') ) {
 				value = decodeURIComponent( value );
 			}
 
-			attr.set( 'value', value );
-		} );
-
-		if ( 'content' in options ) {
-			var innerContent = shortcodeModel.get('inner_content');
-			if ( innerContent ) {
-				// Reverse the effects of wpautop: https://core.trac.wordpress.org/ticket/34329
-				options.content = self.unAutoP( options.content );
-				innerContent.set('value', options.content );
+			if ( attr ) {
+				attr.set( 'value', value );
+			} else {
+				attributes_backup[ key ] = value;
 			}
 		}
 
-		return shortcodeModel;
+		currentShortcode.set( 'attributes_backup', attributes_backup );
+
+		if ( options.content ) {
+			var inner_content = currentShortcode.get( 'inner_content' );
+			if ( inner_content ) {
+				inner_content.set( 'value', this.unAutoP( options.content ) );
+			} else {
+				currentShortcode.set( 'inner_content_backup', this.unAutoP( options.content ) );
+			}
+		}
+
+		return currentShortcode;
 	},
 
 	/**
@@ -604,43 +607,8 @@ var shortcodeViewConstructor = {
 			return;
 		}
 
-		currentShortcode = defaultShortcode.clone();
-
-		var attributes_backup = {};
-		var attributes = wp.shortcode.attrs( matches[3] );
-
-		for ( var key in attributes.named ) {
-
-			if ( ! attributes.named.hasOwnProperty( key ) ) {
-				continue;
-			}
-
-			value = attributes.named[ key ];
-			attr  = currentShortcode.get( 'attrs' ).findWhere({ attr: key });
-
-			if ( attr && attr.get('encode') ) {
-				value = decodeURIComponent( value );
-			}
-
-			if ( attr ) {
-				attr.set( 'value', value );
-			} else {
-				attributes_backup[ key ] = value;
-			}
-		}
-
-		currentShortcode.set( 'attributes_backup', attributes_backup );
-
-		if ( matches[5] ) {
-			var inner_content = currentShortcode.get( 'inner_content' );
-			if ( inner_content ) {
-				inner_content.set( 'value', this.unAutoP( matches[5] ) );
-			} else {
-				currentShortcode.set( 'inner_content_backup', this.unAutoP( matches[5] ) );
-			}
-		}
-
-		return currentShortcode;
+		var shortcode = wp.shortcode.fromMatch( matches );
+		return this.getShortcodeModel( shortcode );
 	},
 
  	/**

--- a/js/src/utils/shortcode-view-constructor.js
+++ b/js/src/utils/shortcode-view-constructor.js
@@ -79,6 +79,9 @@ var shortcodeViewConstructor = {
 			value = attributes.named[ key ];
 			attr  = currentShortcode.get( 'attrs' ).findWhere({ attr: key });
 
+			// Reverse the effects of wpautop: https://core.trac.wordpress.org/ticket/34329
+			value = this.unAutoP( value );
+
 			if ( attr && attr.get('encode') ) {
 				value = decodeURIComponent( value );
 			}
@@ -94,10 +97,12 @@ var shortcodeViewConstructor = {
 
 		if ( options.content ) {
 			var inner_content = currentShortcode.get( 'inner_content' );
+			// Reverse the effects of wpautop: https://core.trac.wordpress.org/ticket/34329
+			options.content = this.unAutoP( options.content );
 			if ( inner_content ) {
-				inner_content.set( 'value', this.unAutoP( options.content ) );
+				inner_content.set( 'value', options.content );
 			} else {
-				currentShortcode.set( 'inner_content_backup', this.unAutoP( options.content ) );
+				currentShortcode.set( 'inner_content_backup', options.content );
 			}
 		}
 

--- a/js/src/utils/shortcode-view-constructor.js
+++ b/js/src/utils/shortcode-view-constructor.js
@@ -55,11 +55,10 @@ var shortcodeViewConstructor = {
 	 * values.
 	 *
 	 * @this {Shortcode}
-	 * @param {Object} options Options
+	 * @param {Object} options Options formatted as wp.shortcode.
 	 */
 	getShortcodeModel: function( options ) {
-		var shortcodeModel,
-			self = this;
+		var shortcodeModel;
 
 		shortcodeModel = sui.shortcodes.findWhere( { shortcode_tag: options.tag } );
 
@@ -67,38 +66,42 @@ var shortcodeViewConstructor = {
 			return;
 		}
 
-		shortcodeModel = shortcodeModel.clone();
+		currentShortcode = shortcodeModel.clone();
 
-		shortcodeModel.get('attrs').each( function( attr ) {
+		var attributes_backup = {};
+		var attributes = options.attrs;
+		for ( var key in attributes.named ) {
 
-			// Verify value exists for attribute.
-			if ( ! ( attr.get('attr') in options.attrs.named ) ) {
-				return;
+			if ( ! attributes.named.hasOwnProperty( key ) ) {
+				continue;
 			}
 
-			var value = options.attrs.named[ attr.get('attr') ];
+			value = attributes.named[ key ];
+			attr  = currentShortcode.get( 'attrs' ).findWhere({ attr: key });
 
-			// Reverse the effects of wpautop: https://core.trac.wordpress.org/ticket/34329
-			value = self.unAutoP( value );
-
-			// Maybe decode value.
-			if ( attr.get('encode') ) {
+			if ( attr && attr.get('encode') ) {
 				value = decodeURIComponent( value );
 			}
 
-			attr.set( 'value', value );
-		} );
-
-		if ( 'content' in options ) {
-			var innerContent = shortcodeModel.get('inner_content');
-			if ( innerContent ) {
-				// Reverse the effects of wpautop: https://core.trac.wordpress.org/ticket/34329
-				options.content = self.unAutoP( options.content );
-				innerContent.set('value', options.content );
+			if ( attr ) {
+				attr.set( 'value', value );
+			} else {
+				attributes_backup[ key ] = value;
 			}
 		}
 
-		return shortcodeModel;
+		currentShortcode.set( 'attributes_backup', attributes_backup );
+
+		if ( options.content ) {
+			var inner_content = currentShortcode.get( 'inner_content' );
+			if ( inner_content ) {
+				inner_content.set( 'value', this.unAutoP( options.content ) );
+			} else {
+				currentShortcode.set( 'inner_content_backup', this.unAutoP( options.content ) );
+			}
+		}
+
+		return currentShortcode;
 	},
 
 	/**
@@ -205,43 +208,8 @@ var shortcodeViewConstructor = {
 			return;
 		}
 
-		currentShortcode = defaultShortcode.clone();
-
-		var attributes_backup = {};
-		var attributes = wp.shortcode.attrs( matches[3] );
-
-		for ( var key in attributes.named ) {
-
-			if ( ! attributes.named.hasOwnProperty( key ) ) {
-				continue;
-			}
-
-			value = attributes.named[ key ];
-			attr  = currentShortcode.get( 'attrs' ).findWhere({ attr: key });
-
-			if ( attr && attr.get('encode') ) {
-				value = decodeURIComponent( value );
-			}
-
-			if ( attr ) {
-				attr.set( 'value', value );
-			} else {
-				attributes_backup[ key ] = value;
-			}
-		}
-
-		currentShortcode.set( 'attributes_backup', attributes_backup );
-
-		if ( matches[5] ) {
-			var inner_content = currentShortcode.get( 'inner_content' );
-			if ( inner_content ) {
-				inner_content.set( 'value', this.unAutoP( matches[5] ) );
-			} else {
-				currentShortcode.set( 'inner_content_backup', this.unAutoP( matches[5] ) );
-			}
-		}
-
-		return currentShortcode;
+		var shortcode = wp.shortcode.fromMatch( matches );
+		return this.getShortcodeModel( shortcode );
 	},
 
  	/**


### PR DESCRIPTION
Even when the shortcode has already been parsed

See #520
