### PR TITLE
Check that mediaFrame.state().props is defined before accessing it

### DIFF
--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -1605,7 +1605,7 @@ var mediaFrame = postMediaFrame.extend( {
 	},
 
 	resetMediaController: function( event ) {
-		if ( this.state() && this.state().props.get('currentShortcode') ) {
+		if ( this.state() && 'undefined' !== typeof this.state().props && this.state().props.get('currentShortcode') ) {
 			this.mediaController.reset();
 			this.contentRender( 'shortcode-ui', 'insert' );
 		}

--- a/js/src/views/media-frame.js
+++ b/js/src/views/media-frame.js
@@ -52,7 +52,7 @@ var mediaFrame = postMediaFrame.extend( {
 	},
 
 	resetMediaController: function( event ) {
-		if ( this.state() && this.state().props.get('currentShortcode') ) {
+		if ( this.state() && 'undefined' !== typeof this.state().props && this.state().props.get('currentShortcode') ) {
 			this.mediaController.reset();
 			this.contentRender( 'shortcode-ui', 'insert' );
 		}


### PR DESCRIPTION
Avoid javascript TypeError when ckicking on a media frame menu item
which doesn't set the props object that Shortcake uses to pass
`currentShortcode` in between modal frames.

See #538
