### PR TITLE
Ensure `register_shortcode_ui` is always run before getting UI args

### DIFF
--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -129,6 +129,19 @@ class Shortcode_UI {
 	 * @return array
 	 */
 	public function get_shortcodes() {
+
+		if ( ! did_action( 'register_shortcode_ui' ) ) {
+
+			/**
+			 * Register shortcode UI for shortcodes.
+			 *
+			 * Can be used to register shortcode UI only when an editor is being enqueued.
+			 *
+			 * @param array $settings Settings array for the ective WP_Editor.
+			 */
+			do_action( 'register_shortcode_ui', array(), '' );
+		}
+
 		/**
 		 * Filter the returned shortcode UI configuration parameters.
 		 *


### PR DESCRIPTION
Because we need to check shortcode UI args in some non-editor contexts,
we need to make sure the `register_shortcode_ui` hook is always run.

Specifically, this fixes the post select AJAX callback. This bug has
likely existed since the hook was introduced.

See 2e414d3b732f708e20b27354e84dab24f313a22b and
17ef5bc9efd9d90ea38ffdec2eadb7625bd682e9

See #545
