### PR TITLE
Listen for "change" event on radio buttons and checkboxes

### DIFF
--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -1254,9 +1254,11 @@ var editAttributeField = Backbone.View.extend( {
 	tagName: "div",
 
 	events: {
-		'input  input':    'inputChanged',
-		'input  textarea': 'inputChanged',
-		'change select':   'inputChanged',
+		'input  input':                  'inputChanged',
+		'input  textarea':               'inputChanged',
+		'change select':                 'inputChanged',
+		'change input[type="radio"]':    'inputChanged',
+		'change input[type="checkbox"]': 'inputChanged'
 	},
 
 	render: function() {

--- a/js/src/views/edit-attribute-field.js
+++ b/js/src/views/edit-attribute-field.js
@@ -7,9 +7,11 @@ var editAttributeField = Backbone.View.extend( {
 	tagName: "div",
 
 	events: {
-		'input  input':    'inputChanged',
-		'input  textarea': 'inputChanged',
-		'change select':   'inputChanged',
+		'input  input':                  'inputChanged',
+		'input  textarea':               'inputChanged',
+		'change select':                 'inputChanged',
+		'change input[type="radio"]':    'inputChanged',
+		'change input[type="checkbox"]': 'inputChanged'
 	},
 
 	render: function() {


### PR DESCRIPTION
Because these inputs don't actually have a value, they don't trigger an
"input" event. Listening for the "change" event as well on certain kinds
of inputs ensures that the model will be updated appropriately.

See #543 

Fixes an issue which was introduced in 9f5890f, in trying to listen to "input" events for better responsivity in text fields and textareas.
