### PR TITLE
Reset the shortcode regexp's index between each match

### DIFF
--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -162,6 +162,7 @@ var $ = (typeof window !== "undefined" ? window['jQuery'] : typeof global !== "u
 
 describe( 'Shortcode View Constructor', function(){
 
+
 	it( 'Persists inner_content when parsing a shortcode without inner_content attribute defined', function(){
 		var data = {
 			label: 'Test Label',
@@ -279,6 +280,26 @@ describe( 'Shortcode View Constructor', function(){
 		sui.shortcodes.add( data );
 		var model = ShortcodeViewConstructor.getShortcodeModel( shortcode );
 		expect( model.get('attrs').first().get('value') ).toEqual( 'This quote has\n\nMultiple line breaks two\n\nTest one' );
+	});
+
+	it( 'Can parse shortcode content idempotently', function() {
+		sui.shortcodes.add({
+			label: 'Test Label',
+			shortcode_tag: 'no_custom_content',
+			attrs: [
+				{
+					attr:        'foo',
+					label:       'Attribute',
+					type:        'text',
+					value:       'test value',
+					placeholder: 'test placeholder',
+				}
+			]
+		});
+    var shortcodeString = '[no_custom_content foo="bar"]';
+		var firstCall = ShortcodeViewConstructor.parseShortcodeString( shortcodeString );
+		var secondCall = ShortcodeViewConstructor.parseShortcodeString( shortcodeString );
+		expect( secondCall ).toBeDefined();
 	});
 
 });
@@ -1004,6 +1025,7 @@ var shortcodeViewConstructor = {
 
 		var shortcode_tags = _.map( sui.shortcodes.pluck( 'shortcode_tag' ), this.pregQuote ).join( '|' );
 		var regexp = wp.shortcode.regexp( shortcode_tags );
+		regexp.lastIndex = 0;
 		var matches = regexp.exec( shortcodeString );
 
 		if ( ! matches ) {

--- a/js-tests/src/shortcodeViewConstructorSpec.js
+++ b/js-tests/src/shortcodeViewConstructorSpec.js
@@ -5,6 +5,7 @@ var $ = require('jquery');
 
 describe( 'Shortcode View Constructor', function(){
 
+
 	it( 'Persists inner_content when parsing a shortcode without inner_content attribute defined', function(){
 		var data = {
 			label: 'Test Label',
@@ -122,6 +123,26 @@ describe( 'Shortcode View Constructor', function(){
 		sui.shortcodes.add( data );
 		var model = ShortcodeViewConstructor.getShortcodeModel( shortcode );
 		expect( model.get('attrs').first().get('value') ).toEqual( 'This quote has\n\nMultiple line breaks two\n\nTest one' );
+	});
+
+	it( 'Can parse shortcode content idempotently', function() {
+		sui.shortcodes.add({
+			label: 'Test Label',
+			shortcode_tag: 'no_custom_content',
+			attrs: [
+				{
+					attr:        'foo',
+					label:       'Attribute',
+					type:        'text',
+					value:       'test value',
+					placeholder: 'test placeholder',
+				}
+			]
+		});
+    var shortcodeString = '[no_custom_content foo="bar"]';
+		var firstCall = ShortcodeViewConstructor.parseShortcodeString( shortcodeString );
+		var secondCall = ShortcodeViewConstructor.parseShortcodeString( shortcodeString );
+		expect( secondCall ).toBeDefined();
 	});
 
 });

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -598,6 +598,7 @@ var shortcodeViewConstructor = {
 
 		var shortcode_tags = _.map( sui.shortcodes.pluck( 'shortcode_tag' ), this.pregQuote ).join( '|' );
 		var regexp = wp.shortcode.regexp( shortcode_tags );
+		regexp.lastIndex = 0;
 		var matches = regexp.exec( shortcodeString );
 
 		if ( ! matches ) {

--- a/js/src/utils/shortcode-view-constructor.js
+++ b/js/src/utils/shortcode-view-constructor.js
@@ -199,6 +199,7 @@ var shortcodeViewConstructor = {
 
 		var shortcode_tags = _.map( sui.shortcodes.pluck( 'shortcode_tag' ), this.pregQuote ).join( '|' );
 		var regexp = wp.shortcode.regexp( shortcode_tags );
+		regexp.lastIndex = 0;
 		var matches = regexp.exec( shortcodeString );
 
 		if ( ! matches ) {


### PR DESCRIPTION
Because the shortcode Regexp defined by `wp.shortcode.rexexp` is a
global matcher, each time it is `exec()`'d, it preserves the last index
searched up to, and begins searching from that index of the target
string the next time it is run over that target string.

This fixes that problem by resetting the lastIndex counter to 0 before
executing the regex.

See #559
