### PR TITLE
Lock PHPCS to version 2.3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         }
     ],
     "require-dev": {
+        "squizlabs/php_codesniffer": "2.3.4",
         "wp-coding-standards/wpcs": "dev-develop"
     },
     "scripts": {


### PR DESCRIPTION
Prevents whitespace squawks that are happening with the latest version v2.4.0.
