### PR TITLE
Pre select SELECT field with multiple values

### DIFF
--- a/inc/templates/edit-form.tpl.php
+++ b/inc/templates/edit-form.tpl.php
@@ -50,7 +50,7 @@
 		<label for="{{ data.id }}">{{{ data.label }}}</label>
 		<select name="{{ data.attr }}" id="{{ data.id }}" {{{ data.meta }}}>
 			<# _.each( data.options, function( label, value ) { #>
-				<option value="{{ value }}" <# if ( ! _.isEmpty( data.value.filter(function(val) { return val == value; })) ){ print('selected'); } #>>{{ label }}</option>
+				<option value="{{ value }}" <# if ( ! _.isEmpty( _.filter( data.value(function(val) ) ) { return val == value; } ) ) ){ print('selected'); } #>>{{ label }}</option>
 			<# }); #>
 		</select>
 		<# if ( typeof data.description == 'string' ) { #>

--- a/inc/templates/edit-form.tpl.php
+++ b/inc/templates/edit-form.tpl.php
@@ -50,7 +50,7 @@
 		<label for="{{ data.id }}">{{{ data.label }}}</label>
 		<select name="{{ data.attr }}" id="{{ data.id }}" {{{ data.meta }}}>
 			<# _.each( data.options, function( label, value ) { #>
-				<option value="{{ value }}" <# if ( value == data.value ){ print('selected'); } #>>{{ label }}</option>
+				<option value="{{ value }}" <# if ( ! _.isEmpty( data.value.filter(function(val) { return val == value; })) ){ print('selected'); } #>>{{ label }}</option>
 			<# }); #>
 		</select>
 		<# if ( typeof data.description == 'string' ) { #>

--- a/inc/templates/edit-form.tpl.php
+++ b/inc/templates/edit-form.tpl.php
@@ -50,7 +50,7 @@
 		<label for="{{ data.id }}">{{{ data.label }}}</label>
 		<select name="{{ data.attr }}" id="{{ data.id }}" {{{ data.meta }}}>
 			<# _.each( data.options, function( label, value ) { #>
-				<option value="{{ value }}" <# if ( ! _.isEmpty( _.filter( data.value(function(val) ) ) { return val == value; } ) ) ){ print('selected'); } #>>{{ label }}</option>
+				<option value="{{ value }}" <# if ( ! _.isEmpty( _.filter( data.value, function(val) { return val == value; } ) ) ) { print('selected'); } #>>{{ label }}</option>
 			<# }); #>
 		</select>
 		<# if ( typeof data.description == 'string' ) { #>

--- a/inc/templates/edit-form.tpl.php
+++ b/inc/templates/edit-form.tpl.php
@@ -50,7 +50,7 @@
 		<label for="{{ data.id }}">{{{ data.label }}}</label>
 		<select name="{{ data.attr }}" id="{{ data.id }}" {{{ data.meta }}}>
 			<# _.each( data.options, function( label, value ) { #>
-				<option value="{{ value }}" <# if ( ! _.isEmpty( _.filter( data.value, function(val) { return val == value; } ) ) ) { print('selected'); } #>>{{ label }}</option>
+				<option value="{{value}}" <# if ( ! _.isEmpty( _.filter( _.isArray( data.value ) ? data.value : data.value.split(','), function(val) { return val == value; } ) ) ) { print('selected'); } #>>{{ label }}</option>
 			<# }); #>
 		</select>
 		<# if ( typeof data.description == 'string' ) { #>


### PR DESCRIPTION
I came across with a situation where I needed to pre select options in a Select field with multiple values. Perhaps it's easier to understand by inspecting this code:

```
array(
    'label'    => esc_html__( 'Select field', 'reactor' ),
    'attr'     => 'select_field',
    'type'     => 'select',
    'options'  => array( 'First', 'Second', 'Third', 'Fourth', 'Fifth', 'Sixth', 'Seventh', 'Eighth', 'Ninth', 'Tenth' ),
    'value'    => array( 2, 3, 6 ),
    'meta'     => array(
        'multiple' => true,
    ),
    'description' => esc_html__( 'Hold down the Ctrl (windows) / Command (Mac) button to select multiple options.', 'reactor' ),
) 
```

This push request aims to allow this use case while keeping previous functionality.
I think it might be useful for others.
