### PR TITLE
Debug ajax request when other plugins already add a get parameter to ajaxurl

### DIFF
--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -365,7 +365,7 @@ var Fetcher = (function() {
 			return;
 		}
 
-		var request = $.post( ajaxurl + '?action=bulk_do_shortcode', {
+		var request = $.post( (ajaxurl.indexOf('?') == -1) ? ajaxurl + '?action=bulk_do_shortcode' : ajaxurl + '&action=bulk_do_shortcode', {
 				queries: _.pluck( fetcher.queries, 'query' )
 			}
 		);

--- a/js/src/utils/fetcher.js
+++ b/js/src/utils/fetcher.js
@@ -81,7 +81,7 @@ var Fetcher = (function() {
 			return;
 		}
 
-		var request = $.post( ajaxurl + '?action=bulk_do_shortcode', {
+		var request = $.post( (ajaxurl.indexOf('?') == -1) ? ajaxurl + '?action=bulk_do_shortcode' : ajaxurl + '&action=bulk_do_shortcode', {
 				queries: _.pluck( fetcher.queries, 'query' )
 			}
 		);


### PR DESCRIPTION
Hello,

This pull request checks if ajaxurl already contains get parameters that can be added by other plugins (such as WPML).

Xoxo.
Vaince.
