### PR TITLE
Cut Travis' workload in half

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,3 +52,7 @@ script:
 notifications:
   email:
     on_success: never
+
+branches:
+  only:
+    - master


### PR DESCRIPTION
Prevent duplicate builds from running on pull requests by only
triggering branch builds on master
