### PR TITLE
Fix search matching index

### DIFF
--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -63,6 +63,7 @@ var MediaController = wp.media.controller.State.extend({
 	search: function( searchTerm ) {
 		var pattern = new RegExp( searchTerm, "gi" );
 		var filteredModels = sui.shortcodes.filter( function( model ) {
+			pattern.lastIndex = 0;
 			return pattern.test( model.get( "label" ) );
 		});
 		return filteredModels;

--- a/js/src/controllers/media-controller.js
+++ b/js/src/controllers/media-controller.js
@@ -26,6 +26,7 @@ var MediaController = wp.media.controller.State.extend({
 	search: function( searchTerm ) {
 		var pattern = new RegExp( searchTerm, "gi" );
 		var filteredModels = sui.shortcodes.filter( function( model ) {
+			pattern.lastIndex = 0;
 			return pattern.test( model.get( "label" ) );
 		});
 		return filteredModels;

--- a/shortcode-ui.php
+++ b/shortcode-ui.php
@@ -58,7 +58,7 @@ function shortcode_ui_load_textdomain() {
 	$path = dirname( __FILE__ ) . '/languages';
 	// Load the textdomain according to the plugin first
 	$mofile = $domain . '-' . $locale . '.mo';
-	if ( $loaded = load_textdomain( $domain, $path . '/'. $mofile ) ) {
+	if ( $loaded = load_textdomain( $domain, $path . '/' . $mofile ) ) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes #458

Shortcake elements whose name start with the same string might not get included in search due to the RegExp being reused. 

Example: Two content elements:
- Character List
- Character Grid

Search for: Character - only one of the items shows up.
