### PR TITLE
Trigger event callbacks when removing an attachment

### DIFF
--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -959,6 +959,7 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 		e.preventDefault();
 
 		this.model.set( 'value', null );
+		this.triggerCallbacks();
 
 		this.$container.toggleClass( 'has-attachment', false );
 		this.$container.find( '.thumbnail' ).remove();

--- a/js/src/views/edit-attribute-field-attachment.js
+++ b/js/src/views/edit-attribute-field-attachment.js
@@ -175,6 +175,7 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 		e.preventDefault();
 
 		this.model.set( 'value', null );
+		this.triggerCallbacks();
 
 		this.$container.toggleClass( 'has-attachment', false );
 		this.$container.find( '.thumbnail' ).remove();


### PR DESCRIPTION
Ensure that hooks registered on attachment fields are triggered when removing an attachment in the same way that they are when selecting or updating it.

Minor fix, connected to #617.
