### PR TITLE
Extending the events base with: render_new|edit|destroy

### DIFF
--- a/js/src/utils/shortcode-view-constructor.js
+++ b/js/src/utils/shortcode-view-constructor.js
@@ -178,9 +178,13 @@ var shortcodeViewConstructor = {
 			 * Action run after an edit shortcode overlay is rendered.
 			 *
 			 * Called as `shortcode-ui.render_edit`.
+			 *
+			 * @param shortcode (object)
+			 *           Reference to the shortcode model used in this overlay.
 			 */
 			var hookName = 'shortcode-ui.render_edit';
-			wp.shortcake.hooks.doAction( hookName );
+			var shortcode = this.shortcodeModel;
+			wp.shortcake.hooks.doAction( hookName, shortcode );
 
 		}
 

--- a/js/src/utils/shortcode-view-constructor.js
+++ b/js/src/utils/shortcode-view-constructor.js
@@ -179,12 +179,12 @@ var shortcodeViewConstructor = {
 			 *
 			 * Called as `shortcode-ui.render_edit`.
 			 *
-			 * @param shortcode (object)
+			 * @param shortcodeModel (object)
 			 *           Reference to the shortcode model used in this overlay.
 			 */
 			var hookName = 'shortcode-ui.render_edit';
-			var shortcode = this.shortcodeModel;
-			wp.shortcake.hooks.doAction( hookName, shortcode );
+			var shortcodeModel = this.shortcodeModel;
+			wp.shortcake.hooks.doAction( hookName, shortcodeModel );
 
 		}
 

--- a/js/src/utils/shortcode-view-constructor.js
+++ b/js/src/utils/shortcode-view-constructor.js
@@ -173,6 +173,15 @@ var shortcodeViewConstructor = {
 
 			wp_media_frame.open();
 
+			/* Trigger render_edit */
+			/*
+			 * Action run after an edit shortcode overlay is rendered.
+			 *
+			 * Called as `shortcode-ui.render_edit`.
+			 */
+			var hookName = 'shortcode-ui.render_edit';
+			wp.shortcake.hooks.doAction( hookName );
+
 		}
 
 	},

--- a/js/src/views/media-frame.js
+++ b/js/src/views/media-frame.js
@@ -112,7 +112,17 @@ var mediaFrame = postMediaFrame.extend( {
 	},
 
 	insertAction: function() {
+		/* Trigger render_destroy */
+		/*
+		 * Action run before the shortcode overlay is destroyed.
+		 *
+		 * Called as `shortcode-ui.render_destroy`.
+		 */
+		var hookName = 'shortcode-ui.render_destroy';
+		wp.shortcake.hooks.doAction( hookName );
+
 		this.controller.state().insert();
+
 	},
 
 } );

--- a/js/src/views/media-frame.js
+++ b/js/src/views/media-frame.js
@@ -117,9 +117,13 @@ var mediaFrame = postMediaFrame.extend( {
 		 * Action run before the shortcode overlay is destroyed.
 		 *
 		 * Called as `shortcode-ui.render_destroy`.
+		 *
+		 * @param shortcodeModel (object)
+		 *           Reference to the shortcode model used in this overlay.
 		 */
 		var hookName = 'shortcode-ui.render_destroy';
-		wp.shortcake.hooks.doAction( hookName );
+		var shortcodeModel = this.controller.state().props.get( 'currentShortcode' );
+		wp.shortcake.hooks.doAction( hookName, shortcodeModel );
 
 		this.controller.state().insert();
 

--- a/js/src/views/shortcode-ui.js
+++ b/js/src/views/shortcode-ui.js
@@ -99,9 +99,13 @@ var Shortcode_UI = Backbone.View.extend({
 		 * Action run after a new shortcode overlay is rendered.
 		 *
 		 * Called as `shortcode-ui.render_new`.
+		 *
+		 * @param shortcode (object)
+		 *           Reference to the shortcode model used in this overlay.
 		 */
 		var hookName = 'shortcode-ui.render_new';
-		wp.shortcake.hooks.doAction( hookName );
+		var shortcode = this.controller.props.attributes.currentShortcode;
+		wp.shortcake.hooks.doAction( hookName, shortcode );
 
 	},
 

--- a/js/src/views/shortcode-ui.js
+++ b/js/src/views/shortcode-ui.js
@@ -100,12 +100,12 @@ var Shortcode_UI = Backbone.View.extend({
 		 *
 		 * Called as `shortcode-ui.render_new`.
 		 *
-		 * @param shortcode (object)
+		 * @param shortcodeModel (object)
 		 *           Reference to the shortcode model used in this overlay.
 		 */
 		var hookName = 'shortcode-ui.render_new';
-		var shortcode = this.controller.props.attributes.currentShortcode;
-		wp.shortcake.hooks.doAction( hookName, shortcode );
+		var shortcodeModel = this.controller.props.get( 'currentShortcode' );
+		wp.shortcake.hooks.doAction( hookName, shortcodeModel );
 
 	},
 

--- a/js/src/views/shortcode-ui.js
+++ b/js/src/views/shortcode-ui.js
@@ -94,6 +94,15 @@ var Shortcode_UI = Backbone.View.extend({
 
 		this.render();
 
+		/* Trigger render_new */
+		/*
+		 * Action run after a new shortcode overlay is rendered.
+		 *
+		 * Called as `shortcode-ui.render_new`.
+		 */
+		var hookName = 'shortcode-ui.render_new';
+		wp.shortcake.hooks.doAction( hookName );
+
 	},
 
 });


### PR DESCRIPTION
I've made a quick screencast showing what was possible to be achieved with these events being present:
https://shrtm.nu/iB4k
I've tried to make use of the existing wp.shortcake.hooks.addAction using hardcoded shortcodes & attributes needing the rich text editing capabilities, but I encountered a brick wall by not being able to hook at the right moment to discard the rich text editor and update the textarea with the sanitised data (taking care of " / [ / ]) without the need to turn on encoding in the shortcode attribute. 

Usage example:

``` javascript
wp.shortcake.hooks.addAction( 'shortcode-ui.render_edit', function() { 
    console.log( 'The shortcode-ui edit screen was rendered.' );
} );
wp.shortcake.hooks.addAction( 'shortcode-ui.render_new', function() { 
    console.log( 'The shortcode-ui new screen was rendered.' );
} );
wp.shortcake.hooks.addAction( 'shortcode-ui.render_destroy', function() {
    console.log( 'The shortcode-ui screen is going to be destroyed.' );
} );
```

This handles the request here: https://github.com/wp-shortcake/shortcake/issues/616
And also inserts the needed pieces into the plug-in, in order to allow developers to make use of rich text input, as it was requested in: 
https://github.com/wp-shortcake/shortcake/issues/236

If this finds its way into core, I can publish the developments as a separate plug-in which would extend on this for others to be able to easily benefit of the rich text editing capabilities on textarea input fields.
