### PR TITLE
Fix PHPCS in build

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require-dev": {
-        "squizlabs/php_codesniffer": "2.3.4",
+        "squizlabs/php_codesniffer": "2.6.2",
         "wp-coding-standards/wpcs": "dev-develop"
     },
     "scripts": {

--- a/php-tests/test-shortcode-ui.php
+++ b/php-tests/test-shortcode-ui.php
@@ -46,15 +46,15 @@ class Test_Shortcode_UI extends WP_UnitTestCase {
 			'inner_content'       => array(
 				'label'           => '<script>gotcha()</script>',
 				'description'     => '<iframe src="baddomain.com"></iframe>',
-				),
+			),
 			'attrs'               => array(
 				array(
 					'attr'        => 'bar',
 					'label'       => '<strong>gotcha()</strong>',
 					'description' => '<script>banana()</script>',
-					),
 				),
-			) );
+			),
+		) );
 		$shortcodes = Shortcode_UI::get_instance()->get_shortcodes();
 		$this->assertEquals( 'gotcha()', $shortcodes['foo']['inner_content']['label'] );
 		$this->assertEmpty( $shortcodes['foo']['inner_content']['description'] );


### PR DESCRIPTION
Fixes the PHP linting build by upgrading php_codesniffer to meet the updated WPCS requirements, and fix one new indentation issue that PHPCS is complaining about.
