### PR TITLE
add optgroups to select

### DIFF
--- a/inc/templates/edit-form.tpl.php
+++ b/inc/templates/edit-form.tpl.php
@@ -50,7 +50,15 @@
 		<label for="{{ data.id }}">{{{ data.label }}}</label>
 		<select name="{{ data.attr }}" id="{{ data.id }}" {{{ data.meta }}}>
 			<# _.each( data.options, function( label, value ) { #>
-				<option value="{{ value }}" <# if ( value == data.value ){ print('selected'); } #>>{{ label }}</option>
+				<# if ( typeof label == 'object') { #>
+					<optgroup label="{{value}}">
+						<# _.each( label, function( optLabel, optValue ) { #>
+							<option value="{{ optValue }}" <# if ( optValue == data.value ){ print('selected'); } #>>{{ optLabel }}</option>
+						<# }); #>
+					</optgroup>
+				<# } else { #>
+					<option value="{{ value }}" <# if ( value == data.value ){ print('selected'); } #>>{{ label }}</option>
+				<# } #>
 			<# }); #>
 		</select>
 		<# if ( typeof data.description == 'string' ) { #>


### PR DESCRIPTION
Adds optional optgroups to select via multi dimentional arrays.

f.e.: 

``` php
shortcode_ui_register_for_shortcode(
    'short-code',  
    array(
        'label'         => 'ShortCode',
        'listItemImage' => 'dashicons-admin-links',
        'attrs'         => array(
            array(
                'label'     => 'select with optgroups',
                'attr'      => 'name',
                'type'      => 'select',
                'options'   => array(
                    'optgroup Label 1' => array(
                        'opt1' => 'Option 1',
                        'opt2' => 'Option 2',
                    ),
                    'optgroup Label 2' => array(
                        'opt3' => 'Option 3',
                    ),
                ),
            ),
        )
    )
);
```

![example](https://cloud.githubusercontent.com/assets/7127893/18871285/09843110-84b5-11e6-82be-cd3be756b9de.jpg)
