### PR TITLE
Allow percents when using decodeURIComponent for encoded HTML support

### DIFF
--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -484,7 +484,7 @@ var shortcodeViewConstructor = {
 			value = this.unAutoP( value );
 
 			if ( attr && attr.get('encode') ) {
-				value = decodeURIComponent( value );
+				value = decodeURIComponent( value.replace( "%", "&#37;" ) );
 			}
 
 			if ( attr ) {

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -211,7 +211,7 @@ Shortcode = Backbone.Model.extend({
 
 			// Encode textareas incase HTML
 			if ( attr.get( 'encode' ) ) {
-				attr.set( 'value', encodeURIComponent( decodeURIComponent( attr.get( 'value' ) ) ), { silent: true } );
+				attr.set( 'value', encodeURIComponent( decodeURIComponent( attr.get( 'value' ).replace( "%", "&#37;" ) ) ), { silent: true } );
 			}
 
 			attrs.push( attr.get( 'attr' ) + '="' + attr.get( 'value' ) + '"' );

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -484,7 +484,8 @@ var shortcodeViewConstructor = {
 			value = this.unAutoP( value );
 
 			if ( attr && attr.get('encode') ) {
-				value = decodeURIComponent( value.replace( "%", "&#37;" ) );
+				value = decodeURIComponent( value );
+				value = value.replace( "&#37;", "%" );
 			}
 
 			if ( attr ) {

--- a/js/src/models/shortcode.js
+++ b/js/src/models/shortcode.js
@@ -75,7 +75,7 @@ Shortcode = Backbone.Model.extend({
 
 			// Encode textareas incase HTML
 			if ( attr.get( 'encode' ) ) {
-				attr.set( 'value', encodeURIComponent( decodeURIComponent( attr.get( 'value' ).replace( "%", "&#37;" ) ), { silent: true } );
+				attr.set( 'value', encodeURIComponent( decodeURIComponent( attr.get( 'value' ).replace( "%", "&#37;" ) ) ), { silent: true } );
 			}
 
 			attrs.push( attr.get( 'attr' ) + '="' + attr.get( 'value' ) + '"' );

--- a/js/src/models/shortcode.js
+++ b/js/src/models/shortcode.js
@@ -75,7 +75,7 @@ Shortcode = Backbone.Model.extend({
 
 			// Encode textareas incase HTML
 			if ( attr.get( 'encode' ) ) {
-				attr.set( 'value', encodeURIComponent( decodeURIComponent( attr.get( 'value' ) ) ), { silent: true } );
+				attr.set( 'value', encodeURIComponent( decodeURIComponent( attr.get( 'value' ).replace( "%", "&#37;" ) ), { silent: true } );
 			}
 
 			attrs.push( attr.get( 'attr' ) + '="' + attr.get( 'value' ) + '"' );

--- a/js/src/utils/shortcode-view-constructor.js
+++ b/js/src/utils/shortcode-view-constructor.js
@@ -83,7 +83,8 @@ var shortcodeViewConstructor = {
 			value = this.unAutoP( value );
 
 			if ( attr && attr.get('encode') ) {
-				value = decodeURIComponent( value.replace( "%", "&#37;" ) );
+				value = decodeURIComponent( value );
+				value = value.replace( "&#37;", "%" );
 			}
 
 			if ( attr ) {

--- a/js/src/utils/shortcode-view-constructor.js
+++ b/js/src/utils/shortcode-view-constructor.js
@@ -83,7 +83,7 @@ var shortcodeViewConstructor = {
 			value = this.unAutoP( value );
 
 			if ( attr && attr.get('encode') ) {
-				value = decodeURIComponent( value );
+				value = decodeURIComponent( value.replace( "%", "&#37;" ) );
 			}
 
 			if ( attr ) {


### PR DESCRIPTION
Fixes #634

Support percent characters in values that get encoded, otherwise JS errors like `Uncaught URIError: URI malformed(…)` happen and stop the shortcode embedding process.
