### PR TITLE
Use pre 4.5 arguments notation for get_terms to maintain compatibility

### DIFF
--- a/inc/fields/class-field-term-select.php
+++ b/inc/fields/class-field-term-select.php
@@ -172,7 +172,7 @@ class Shortcode_UI_Field_Term_Select {
 			$args['offset'] = ( $page - 1 ) * $response['terms_per_page'];
 		}
 
-		$results = get_terms( $args );
+		$results = get_terms( $taxonomy_type, $args );
 
 		foreach ( $results as $result ) {
 			array_push( $response['terms'], array( 'id' => $result->term_id, 'text' => html_entity_decode( $result->name ) ) );


### PR DESCRIPTION
This should fix issue #648 
