### PR TITLE
Use post params to build ajax endpoint rather than string concatenation

### DIFF
--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -838,7 +838,8 @@ var Fetcher = (function() {
 			return;
 		}
 
-		var request = $.post( ajaxurl + '?action=bulk_do_shortcode', {
+		var request = $.post( ajaxurl, {
+				action: 'bulk_do_shortcode',
 				queries: _.pluck( fetcher.queries, 'query' )
 			}
 		);

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -838,14 +838,12 @@ var Fetcher = (function() {
 			return;
 		}
 
-		var request = $.post( ajaxurl, {
-				action: 'bulk_do_shortcode',
-				queries: _.pluck( fetcher.queries, 'query' )
-			}
-		);
+		var request = wp.ajax.post( 'bulk_do_shortcode', {
+			queries: _.pluck( fetcher.queries, 'query' )
+		});
 
-		request.done( function( response ) {
-			_.each( response.data, function( result, index ) {
+		request.done( function( responseData ) {
+			_.each( responseData, function( result, index ) {
 				var matchedQuery = _.findWhere( fetcher.queries, {
 					counter: parseInt( index ),
 				});

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -388,7 +388,8 @@ var Fetcher = (function() {
 			return;
 		}
 
-		var request = $.post( ajaxurl + '?action=bulk_do_shortcode', {
+		var request = $.post( ajaxurl, {
+				action: 'bulk_do_shortcode',
 				queries: _.pluck( fetcher.queries, 'query' )
 			}
 		);

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -388,14 +388,12 @@ var Fetcher = (function() {
 			return;
 		}
 
-		var request = $.post( ajaxurl, {
-				action: 'bulk_do_shortcode',
-				queries: _.pluck( fetcher.queries, 'query' )
-			}
-		);
+		var request = wp.ajax.post( 'bulk_do_shortcode', {
+			queries: _.pluck( fetcher.queries, 'query' )
+		});
 
-		request.done( function( response ) {
-			_.each( response.data, function( result, index ) {
+		request.done( function( responseData ) {
+			_.each( responseData, function( result, index ) {
 				var matchedQuery = _.findWhere( fetcher.queries, {
 					counter: parseInt( index ),
 				});

--- a/js/src/utils/fetcher.js
+++ b/js/src/utils/fetcher.js
@@ -81,14 +81,12 @@ var Fetcher = (function() {
 			return;
 		}
 
-		var request = $.post( ajaxurl, {
-				action: 'bulk_do_shortcode',
-				queries: _.pluck( fetcher.queries, 'query' )
-			}
-		);
+		var request = wp.ajax.post( 'bulk_do_shortcode', {
+			queries: _.pluck( fetcher.queries, 'query' )
+		});
 
-		request.done( function( response ) {
-			_.each( response.data, function( result, index ) {
+		request.done( function( responseData ) {
+			_.each( responseData, function( result, index ) {
 				var matchedQuery = _.findWhere( fetcher.queries, {
 					counter: parseInt( index ),
 				});

--- a/js/src/utils/fetcher.js
+++ b/js/src/utils/fetcher.js
@@ -81,7 +81,8 @@ var Fetcher = (function() {
 			return;
 		}
 
-		var request = $.post( ajaxurl + '?action=bulk_do_shortcode', {
+		var request = $.post( ajaxurl, {
+				action: 'bulk_do_shortcode',
 				queries: _.pluck( fetcher.queries, 'query' )
 			}
 		);


### PR DESCRIPTION
Rather than building the admin-ajax url to post a bulk preview request to, use a post parameter to specify the action.

Adds compatability with WPML and other plugins which filter the admin-ajax url to add additional query string parameters to it. Also, it seems like better practice to use request parameters rather than concatenating strings to build urls.

An alternate approach to #568