### PR TITLE
Support svg images for attachment field thumbnail preview

### DIFF
--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -805,12 +805,13 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 
 		} else {
 
-			attachmentThumb = (typeof attachment.sizes.thumbnail !== 'undefined') ?
-				attachment.sizes.thumbnail :
-				_.first( _.sortBy( attachment.sizes, 'width' ) );
+			attachmentThumb = (
+				typeof attachment.sizes !== 'undefined' &&
+				typeof attachment.sizes.thumbnail !== 'undefined'
+			) ? attachment.sizes.thumbnail : _.first( _.sortBy( attachment.sizes, 'width' ) ) || {};
 
 			jQuery( '<img/>', {
-				src:    attachmentThumb.url,
+				src:    attachmentThumb.url || attachment.url,
 				width:  attachmentThumb.width,
 				height: attachmentThumb.height,
 				alt:    attachment.alt,

--- a/js/src/views/edit-attribute-field-attachment.js
+++ b/js/src/views/edit-attribute-field-attachment.js
@@ -103,9 +103,10 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 
 		} else {
 
-			attachmentThumb = (typeof attachment.sizes.thumbnail !== 'undefined') ?
-				attachment.sizes.thumbnail :
-				_.first( _.sortBy( attachment.sizes, 'width' ) ) || {};
+			attachmentThumb = (
+				typeof attachment.sizes !== 'undefined' &&
+				typeof attachment.sizes.thumbnail !== 'undefined'
+			) ? attachment.sizes.thumbnail : _.first( _.sortBy( attachment.sizes, 'width' ) ) || {};
 
 			jQuery( '<img/>', {
 				src:    attachmentThumb.url || attachment.url,

--- a/js/src/views/edit-attribute-field-attachment.js
+++ b/js/src/views/edit-attribute-field-attachment.js
@@ -105,10 +105,10 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 
 			attachmentThumb = (typeof attachment.sizes.thumbnail !== 'undefined') ?
 				attachment.sizes.thumbnail :
-				_.first( _.sortBy( attachment.sizes, 'width' ) );
+				_.first( _.sortBy( attachment.sizes, 'width' ) ) || {};
 
 			jQuery( '<img/>', {
-				src:    attachmentThumb.url,
+				src:    attachmentThumb.url || attachment.url,
 				width:  attachmentThumb.width,
 				height: attachmentThumb.height,
 				alt:    attachment.alt,


### PR DESCRIPTION
This is #605, rebased on top of current master and with the build files checked in.