### PR TITLE
646 update to select2 4 bugs

### DIFF
--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -1619,7 +1619,7 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 		var _selected = $( e.currentTarget ).val();
 
 		// Store multiple selections as comma-delimited list
-		if ( 'object' === typeof _selected ) {
+		if ( Array.isArray( _selected ) ) {
 			_selected = _selected.join( ',' );
 		}
 

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -1719,7 +1719,7 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 				},
 				processResults: function (response, params) {
 					if ( ! response.success || 'undefined' === typeof response.data ) {
-						return;
+						return { results: [] };
 					}
 					var data = response.data;
 					params.page = params.page || 1;

--- a/js/src/views/select2-field.js
+++ b/js/src/views/select2-field.js
@@ -121,7 +121,7 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 				},
 				processResults: function (response, params) {
 					if ( ! response.success || 'undefined' === typeof response.data ) {
-						return;
+						return { results: [] };
 					}
 					var data = response.data;
 					params.page = params.page || 1;

--- a/js/src/views/select2-field.js
+++ b/js/src/views/select2-field.js
@@ -21,7 +21,7 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 		var _selected = $( e.currentTarget ).val();
 
 		// Store multiple selections as comma-delimited list
-		if ( 'object' === typeof _selected ) {
+		if ( Array.isArray( _selected ) ) {
 			_selected = _selected.join( ',' );
 		}
 


### PR DESCRIPTION
Ran into a couple of bugs in the new Select2 4 implementation

- If you don't select a value, an error is triggered trying to call `join` on `null` when updating. This is because JavaScript being JavaScript, `'object' === typeof null` is true!
- Error when term select field doesn't return any results. I think the processResults callback should always items, even if its empty.