### PR TITLE
Don’t URL encode output from color picker in dev.php example

### DIFF
--- a/dev.php
+++ b/dev.php
@@ -213,7 +213,7 @@ function shortcode_ui_dev_advanced_example() {
 			'label'  => esc_html__( 'Color', 'shortcode-ui-example' ),
 			'attr'   => 'color',
 			'type'   => 'color',
-			'encode' => true,
+			'encode' => false,
 			'meta'   => array(
 				'placeholder' => esc_html__( 'Hex color code', 'shortcode-ui-example' ),
 			),


### PR DESCRIPTION
See https://github.com/wp-shortcake/shortcake/issues/577#issuecomment-264002615

@goldenapples review/merge?