### PR TITLE
Add space before self-closing slash in shortcode

### DIFF
--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -119,11 +119,11 @@ describe( "Shortcode Model", function() {
 
 		// Test without content.
 		_shortcode.get('inner_content').unset( 'value' );
-		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode attr="test value"/]' );
+		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode attr="test value" /]' );
 
 		// Test without attributes
 		_shortcode.get( 'attrs' ).first().unset( 'value' );
-		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode/]' );
+		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode /]' );
 
 	});
 
@@ -145,7 +145,7 @@ describe( "Shortcode Model", function() {
 		});
 
 		formatted = shortcode_encoded_attribute.formatShortcode();
-		expected  = '[test_shortcode_encoded attr="%3Cb%20class%3D%22foo%22%3Ebar%3C%2Fb%3E"/]';
+		expected  = '[test_shortcode_encoded attr="%3Cb%20class%3D%22foo%22%3Ebar%3C%2Fb%3E" /]';
 		expect( formatted ).toEqual( expected );
 
 	});
@@ -215,7 +215,7 @@ describe( 'Shortcode View Constructor', function(){
 		sui.shortcodes.add( data );
 		var shortcode = ShortcodeViewConstructor.parseShortcodeString( '[no_custom_attribute foo="bar" bar="banana"]' );
 		var _shortcode = $.extend( true, {}, shortcode );
-		expect( _shortcode.formatShortcode() ).toEqual( '[no_custom_attribute foo="bar" bar="banana"/]' );
+		expect( _shortcode.formatShortcode() ).toEqual( '[no_custom_attribute foo="bar" bar="banana" /]' );
 		ShortcodeViewConstructor.shortcode = {
 			'type' : 'single',
 			'tag' : 'no_custom_attribute',
@@ -232,7 +232,7 @@ describe( 'Shortcode View Constructor', function(){
 			return new $.Deferred();
 		};
 		ShortcodeViewConstructor.initialize();
-		expect( ShortcodeViewConstructor.shortcodeModel.formatShortcode() ).toEqual( '[no_custom_attribute foo="bar" bar="banana"/]' );
+		expect( ShortcodeViewConstructor.shortcodeModel.formatShortcode() ).toEqual( '[no_custom_attribute foo="bar" bar="banana" /]' );
 	});
 
 	it( 'Reverses the effect of core adding wpautop to shortcode inner content', function(){
@@ -798,7 +798,7 @@ Shortcode = Backbone.Model.extend({
 			template += "]{{ content }}[/{{ shortcode }}]";
 		} else {
 			// add closing slash to shortcodes without content
-			template += "/]";
+			template += " /]";
 		}
 
 		template = template.replace( /{{ shortcode }}/g, this.get('shortcode_tag') );

--- a/js-tests/src/shortcodeModelSpec.js
+++ b/js-tests/src/shortcodeModelSpec.js
@@ -62,11 +62,11 @@ describe( "Shortcode Model", function() {
 
 		// Test without content.
 		_shortcode.get('inner_content').unset( 'value' );
-		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode attr="test value"/]' );
+		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode attr="test value" /]' );
 
 		// Test without attributes
 		_shortcode.get( 'attrs' ).first().unset( 'value' );
-		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode/]' );
+		expect( _shortcode.formatShortcode() ).toEqual( '[test_shortcode /]' );
 
 	});
 
@@ -88,7 +88,7 @@ describe( "Shortcode Model", function() {
 		});
 
 		formatted = shortcode_encoded_attribute.formatShortcode();
-		expected  = '[test_shortcode_encoded attr="%3Cb%20class%3D%22foo%22%3Ebar%3C%2Fb%3E"/]';
+		expected  = '[test_shortcode_encoded attr="%3Cb%20class%3D%22foo%22%3Ebar%3C%2Fb%3E" /]';
 		expect( formatted ).toEqual( expected );
 
 	});

--- a/js-tests/src/shortcodeViewConstructorSpec.js
+++ b/js-tests/src/shortcodeViewConstructorSpec.js
@@ -58,7 +58,7 @@ describe( 'Shortcode View Constructor', function(){
 		sui.shortcodes.add( data );
 		var shortcode = ShortcodeViewConstructor.parseShortcodeString( '[no_custom_attribute foo="bar" bar="banana"]' );
 		var _shortcode = $.extend( true, {}, shortcode );
-		expect( _shortcode.formatShortcode() ).toEqual( '[no_custom_attribute foo="bar" bar="banana"/]' );
+		expect( _shortcode.formatShortcode() ).toEqual( '[no_custom_attribute foo="bar" bar="banana" /]' );
 		ShortcodeViewConstructor.shortcode = {
 			'type' : 'single',
 			'tag' : 'no_custom_attribute',
@@ -75,7 +75,7 @@ describe( 'Shortcode View Constructor', function(){
 			return new $.Deferred();
 		};
 		ShortcodeViewConstructor.initialize();
-		expect( ShortcodeViewConstructor.shortcodeModel.formatShortcode() ).toEqual( '[no_custom_attribute foo="bar" bar="banana"/]' );
+		expect( ShortcodeViewConstructor.shortcodeModel.formatShortcode() ).toEqual( '[no_custom_attribute foo="bar" bar="banana" /]' );
 	});
 
 	it( 'Reverses the effect of core adding wpautop to shortcode inner content', function(){

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -238,7 +238,7 @@ Shortcode = Backbone.Model.extend({
 			template += "]{{ content }}[/{{ shortcode }}]";
 		} else {
 			// add closing slash to shortcodes without content
-			template += "/]";
+			template += " /]";
 		}
 
 		template = template.replace( /{{ shortcode }}/g, this.get('shortcode_tag') );

--- a/js/src/models/shortcode.js
+++ b/js/src/models/shortcode.js
@@ -102,7 +102,7 @@ Shortcode = Backbone.Model.extend({
 			template += "]{{ content }}[/{{ shortcode }}]";
 		} else {
 			// add closing slash to shortcodes without content
-			template += "/]";
+			template += " /]";
 		}
 
 		template = template.replace( /{{ shortcode }}/g, this.get('shortcode_tag') );


### PR DESCRIPTION
If a shortcode has no inner content, it will be formatted with a
self-closing slash to avoid confusion. However, that slash was being
inserted right after the last attribute, which doesn't follow WordPress
style guidelines.

This adds a space before the closing slash on self-closing shortcode
strings.

From suggestions in #663.