### PR TITLE
For select fields, set model value on initial render

### DIFF
--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -612,6 +612,43 @@ describe( 'Edit Attribute Field', function(){
 		spyOn( window, 'attr1RenderCallback' );
 	});
 
+	describe( 'Select field', function() {
+		var selectFieldAttribute, selectFieldView, selectFieldModel;
+
+		selectFieldAttribute = {
+			attr: 'select_field',
+			label: 'Select Attribute Field',
+			type: 'select',
+			options: {
+				one: 'one',
+				two: 'two',
+				three: 'three'
+			}
+		};
+
+		shortcodeData.attrs = [ selectFieldAttribute ];
+		shortcodeModel = new Shortcode( shortcodeData );
+
+		selectFieldModel = new ShortcodeAttribute(
+			shortcodeModel.get('attrs').models[0].attributes
+		);
+		selectFieldView = new EditAttributeField({ model: selectFieldModel });
+		selectFieldView.shortcode = shortcodeModel;
+		selectFieldView.template = selectFieldView.triggerCallbacks =  function( data ) {};
+		selectFieldView.template = function( data ) {};
+
+		it( 'should use first option as the default if no empty option is set', function() {
+			selectFieldView.render();
+			expect( selectFieldModel.get( 'value' ) ).toBe( 'one' );
+		});
+
+		it( 'should respect selected value if one is already set', function() {
+			selectFieldView.setValue( 'two' );
+			selectFieldView.render();
+			expect( selectFieldModel.get( 'value' ) ).toBe( 'two' );
+		});
+	});
+
 });
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -1298,12 +1298,15 @@ var editAttributeField = Backbone.View.extend( {
 
 		this.$el.html( this.template( data ) );
 
+		// Ensure default value for select field.
 		if ( 'select' === data.type && '' === this.model.get( 'value' ) ) {
 			var firstVisibleOption = _.first( data.options );
 			if ( 'undefined' !== typeof firstVisibleOption.value ) {
 				this.setValue( firstVisibleOption.value );
 			}
 		}
+
+		this.$el.html( this.template( data ) );
 
 		this.triggerCallbacks();
 

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -649,6 +649,38 @@ describe( 'Edit Attribute Field', function(){
 		});
 	});
 
+	describe( 'Select field with null attribute', function() {
+		var selectFieldAttribute, selectFieldView, selectFieldModel;
+
+		selectFieldAttribute = {
+			attr: 'select_field',
+			label: 'Select Attribute Field',
+			type: 'select',
+			options: {
+				one: 'one',
+				two: 'two',
+				'': 'no value',
+				three: 'three'
+			}
+		};
+
+		shortcodeData.attrs = [ selectFieldAttribute ];
+		shortcodeModel = new Shortcode( shortcodeData );
+
+		selectFieldModel = new ShortcodeAttribute(
+			shortcodeModel.get('attrs').models[0].attributes
+		);
+		selectFieldView = new EditAttributeField({ model: selectFieldModel });
+		selectFieldView.shortcode = shortcodeModel;
+		selectFieldView.template = selectFieldView.triggerCallbacks =  function( data ) {};
+		selectFieldView.template = function( data ) {};
+
+		it( 'should not use first option as the default if an empty option is set', function() {
+			selectFieldView.render();
+			expect( selectFieldModel.get( 'value' ) ).toBe( '' );
+		});
+	});
+
 });
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
@@ -1296,16 +1328,16 @@ var editAttributeField = Backbone.View.extend( {
 			data.options = this.parseOptions( data.options );
 		}
 
-		this.$el.html( this.template( data ) );
-
 		// Ensure default value for select field.
-		if ( 'select' === data.type && '' === this.model.get( 'value' ) ) {
+		if ( 'select' === data.type && '' === this.model.get( 'value' ) && ! _.findWhere( data.options, { value: '' } ) ) {
 			var firstVisibleOption = _.first( data.options );
 			if ( 'undefined' !== typeof firstVisibleOption.value ) {
 				this.setValue( firstVisibleOption.value );
+				data.value = firstVisibleOption.value;
 			}
 		}
 
+		this.$el.html( this.template( data ) );
 		this.triggerCallbacks();
 
 		return this;

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -1306,8 +1306,6 @@ var editAttributeField = Backbone.View.extend( {
 			}
 		}
 
-		this.$el.html( this.template( data ) );
-
 		this.triggerCallbacks();
 
 		return this;

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -1260,6 +1260,14 @@ var editAttributeField = Backbone.View.extend( {
 		}
 
 		this.$el.html( this.template( data ) );
+
+		if ( 'select' === data.type && '' === this.model.get( 'value' ) ) {
+			var firstVisibleOption = _.first( data.options );
+			if ( 'undefined' !== typeof firstVisibleOption.value ) {
+				this.setValue( firstVisibleOption.value );
+			}
+		}
+
 		this.triggerCallbacks();
 
 		return this;

--- a/js-tests/src/views/editAttributeFieldSpec.js
+++ b/js-tests/src/views/editAttributeFieldSpec.js
@@ -52,4 +52,41 @@ describe( 'Edit Attribute Field', function(){
 		spyOn( window, 'attr1RenderCallback' );
 	});
 
+	describe( 'Select field', function() {
+		var selectFieldAttribute, selectFieldView, selectFieldModel;
+
+		selectFieldAttribute = {
+			attr: 'select_field',
+			label: 'Select Attribute Field',
+			type: 'select',
+			options: {
+				one: 'one',
+				two: 'two',
+				three: 'three'
+			}
+		};
+
+		shortcodeData.attrs = [ selectFieldAttribute ];
+		shortcodeModel = new Shortcode( shortcodeData );
+
+		selectFieldModel = new ShortcodeAttribute(
+			shortcodeModel.get('attrs').models[0].attributes
+		);
+		selectFieldView = new EditAttributeField({ model: selectFieldModel });
+		selectFieldView.shortcode = shortcodeModel;
+		selectFieldView.template = selectFieldView.triggerCallbacks =  function( data ) {};
+		selectFieldView.template = function( data ) {};
+
+		it( 'should use first option as the default if no empty option is set', function() {
+			selectFieldView.render();
+			expect( selectFieldModel.get( 'value' ) ).toBe( 'one' );
+		});
+
+		it( 'should respect selected value if one is already set', function() {
+			selectFieldView.setValue( 'two' );
+			selectFieldView.render();
+			expect( selectFieldModel.get( 'value' ) ).toBe( 'two' );
+		});
+	});
+
 });

--- a/js-tests/src/views/editAttributeFieldSpec.js
+++ b/js-tests/src/views/editAttributeFieldSpec.js
@@ -89,4 +89,36 @@ describe( 'Edit Attribute Field', function(){
 		});
 	});
 
+	describe( 'Select field with null attribute', function() {
+		var selectFieldAttribute, selectFieldView, selectFieldModel;
+
+		selectFieldAttribute = {
+			attr: 'select_field',
+			label: 'Select Attribute Field',
+			type: 'select',
+			options: {
+				one: 'one',
+				two: 'two',
+				'': 'no value',
+				three: 'three'
+			}
+		};
+
+		shortcodeData.attrs = [ selectFieldAttribute ];
+		shortcodeModel = new Shortcode( shortcodeData );
+
+		selectFieldModel = new ShortcodeAttribute(
+			shortcodeModel.get('attrs').models[0].attributes
+		);
+		selectFieldView = new EditAttributeField({ model: selectFieldModel });
+		selectFieldView.shortcode = shortcodeModel;
+		selectFieldView.template = selectFieldView.triggerCallbacks =  function( data ) {};
+		selectFieldView.template = function( data ) {};
+
+		it( 'should not use first option as the default if an empty option is set', function() {
+			selectFieldView.render();
+			expect( selectFieldModel.get( 'value' ) ).toBe( '' );
+		});
+	});
+
 });

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -1145,12 +1145,15 @@ var editAttributeField = Backbone.View.extend( {
 
 		this.$el.html( this.template( data ) );
 
+		// Ensure default value for select field.
 		if ( 'select' === data.type && '' === this.model.get( 'value' ) ) {
 			var firstVisibleOption = _.first( data.options );
 			if ( 'undefined' !== typeof firstVisibleOption.value ) {
 				this.setValue( firstVisibleOption.value );
 			}
 		}
+
+		this.$el.html( this.template( data ) );
 
 		this.triggerCallbacks();
 

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -1144,6 +1144,14 @@ var editAttributeField = Backbone.View.extend( {
 		}
 
 		this.$el.html( this.template( data ) );
+
+		if ( 'select' === data.type && '' === this.model.get( 'value' ) ) {
+			var firstVisibleOption = _.first( data.options );
+			if ( 'undefined' !== typeof firstVisibleOption.value ) {
+				this.setValue( firstVisibleOption.value );
+			}
+		}
+
 		this.triggerCallbacks();
 
 		return this;

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -1153,8 +1153,6 @@ var editAttributeField = Backbone.View.extend( {
 			}
 		}
 
-		this.$el.html( this.template( data ) );
-
 		this.triggerCallbacks();
 
 		return this;

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -1143,16 +1143,16 @@ var editAttributeField = Backbone.View.extend( {
 			data.options = this.parseOptions( data.options );
 		}
 
-		this.$el.html( this.template( data ) );
-
 		// Ensure default value for select field.
-		if ( 'select' === data.type && '' === this.model.get( 'value' ) ) {
+		if ( 'select' === data.type && '' === this.model.get( 'value' ) && ! _.findWhere( data.options, { value: '' } ) ) {
 			var firstVisibleOption = _.first( data.options );
 			if ( 'undefined' !== typeof firstVisibleOption.value ) {
 				this.setValue( firstVisibleOption.value );
+				data.value = firstVisibleOption.value;
 			}
 		}
 
+		this.$el.html( this.template( data ) );
 		this.triggerCallbacks();
 
 		return this;

--- a/js/src/views/edit-attribute-field.js
+++ b/js/src/views/edit-attribute-field.js
@@ -48,6 +48,14 @@ var editAttributeField = Backbone.View.extend( {
 		}
 
 		this.$el.html( this.template( data ) );
+
+		if ( 'select' === data.type && '' === this.model.get( 'value' ) ) {
+			var firstVisibleOption = _.first( data.options );
+			if ( 'undefined' !== typeof firstVisibleOption.value ) {
+				this.setValue( firstVisibleOption.value );
+			}
+		}
+
 		this.triggerCallbacks();
 
 		return this;

--- a/js/src/views/edit-attribute-field.js
+++ b/js/src/views/edit-attribute-field.js
@@ -47,16 +47,16 @@ var editAttributeField = Backbone.View.extend( {
 			data.options = this.parseOptions( data.options );
 		}
 
-		this.$el.html( this.template( data ) );
-
 		// Ensure default value for select field.
-		if ( 'select' === data.type && '' === this.model.get( 'value' ) ) {
+		if ( 'select' === data.type && '' === this.model.get( 'value' ) && ! _.findWhere( data.options, { value: '' } ) ) {
 			var firstVisibleOption = _.first( data.options );
 			if ( 'undefined' !== typeof firstVisibleOption.value ) {
 				this.setValue( firstVisibleOption.value );
+				data.value = firstVisibleOption.value;
 			}
 		}
 
+		this.$el.html( this.template( data ) );
 		this.triggerCallbacks();
 
 		return this;

--- a/js/src/views/edit-attribute-field.js
+++ b/js/src/views/edit-attribute-field.js
@@ -49,6 +49,7 @@ var editAttributeField = Backbone.View.extend( {
 
 		this.$el.html( this.template( data ) );
 
+		// Ensure default value for select field.
 		if ( 'select' === data.type && '' === this.model.get( 'value' ) ) {
 			var firstVisibleOption = _.first( data.options );
 			if ( 'undefined' !== typeof firstVisibleOption.value ) {


### PR DESCRIPTION
Select fields are a bit of a special case as far as attribute fields go, in that the select element's value in the UI can appear to be set without the model value itself being defined. This change handles cases where there's no empty value in the select field, so the first option should function as a default value.

When a select field is rendered, if the model's value is empty and the first element isn't an empty option, this will set the model's value to the value of the option which is visibly selected, to avoid confusion.

Fixes #668