### PR TITLE
Handle options with empty values in select fields

### DIFF
--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -647,24 +647,6 @@ describe( 'Edit Attribute Field', function(){
 			selectFieldView.render();
 			expect( selectFieldModel.get( 'value' ) ).toBe( 'two' );
 		});
-
-		/*
-		selectFieldAttribute.options[''] = 'no value';
-		shortcodeData.attrs = [ selectFieldAttribute ];
-		shortcodeModel = new Shortcode( shortcodeData );
-
-		selectFieldModel = new ShortcodeAttribute(
-			shortcodeModel.get('attrs').models[0].attributes
-		);
-		selectFieldView = new EditAttributeField({ model: selectFieldModel });
-		selectFieldView.shortcode = shortcodeModel;
-
-		it( 'should allow an empty value, even when not the first option', function() {
-			selectFieldView.render();
-			expect( selectFieldModel.get( 'value' ) ).toBe( 'two' );
-
-		});
-		*/
 	});
 
 	describe( 'Select field with null attribute', function() {

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -647,6 +647,56 @@ describe( 'Edit Attribute Field', function(){
 			selectFieldView.render();
 			expect( selectFieldModel.get( 'value' ) ).toBe( 'two' );
 		});
+
+		/*
+		selectFieldAttribute.options[''] = 'no value';
+		shortcodeData.attrs = [ selectFieldAttribute ];
+		shortcodeModel = new Shortcode( shortcodeData );
+
+		selectFieldModel = new ShortcodeAttribute(
+			shortcodeModel.get('attrs').models[0].attributes
+		);
+		selectFieldView = new EditAttributeField({ model: selectFieldModel });
+		selectFieldView.shortcode = shortcodeModel;
+
+		it( 'should allow an empty value, even when not the first option', function() {
+			selectFieldView.render();
+			expect( selectFieldModel.get( 'value' ) ).toBe( 'two' );
+
+		});
+		*/
+	});
+
+	describe( 'Select field with null attribute', function() {
+		var selectFieldAttribute, selectFieldView, selectFieldModel;
+
+		selectFieldAttribute = {
+			attr: 'select_field',
+			label: 'Select Attribute Field',
+			type: 'select',
+			options: {
+				one: 'one',
+				two: 'two',
+				'': 'no value',
+				three: 'three'
+			}
+		};
+
+		shortcodeData.attrs = [ selectFieldAttribute ];
+		shortcodeModel = new Shortcode( shortcodeData );
+
+		selectFieldModel = new ShortcodeAttribute(
+			shortcodeModel.get('attrs').models[0].attributes
+		);
+		selectFieldView = new EditAttributeField({ model: selectFieldModel });
+		selectFieldView.shortcode = shortcodeModel;
+		selectFieldView.template = selectFieldView.triggerCallbacks =  function( data ) {};
+		selectFieldView.template = function( data ) {};
+
+		it( 'should not use first option as the default if an empty option is set', function() {
+			selectFieldView.render();
+			expect( selectFieldModel.get( 'value' ) ).toBe( '' );
+		});
 	});
 
 });
@@ -1296,16 +1346,16 @@ var editAttributeField = Backbone.View.extend( {
 			data.options = this.parseOptions( data.options );
 		}
 
-		this.$el.html( this.template( data ) );
-
 		// Ensure default value for select field.
-		if ( 'select' === data.type && '' === this.model.get( 'value' ) ) {
+		if ( 'select' === data.type && '' === this.model.get( 'value' ) && ! _.findWhere( data.options, { value: '' } ) ) {
 			var firstVisibleOption = _.first( data.options );
 			if ( 'undefined' !== typeof firstVisibleOption.value ) {
 				this.setValue( firstVisibleOption.value );
+				data.value = firstVisibleOption.value;
 			}
 		}
 
+		this.$el.html( this.template( data ) );
 		this.triggerCallbacks();
 
 		return this;

--- a/js-tests/src/views/editAttributeFieldSpec.js
+++ b/js-tests/src/views/editAttributeFieldSpec.js
@@ -87,24 +87,6 @@ describe( 'Edit Attribute Field', function(){
 			selectFieldView.render();
 			expect( selectFieldModel.get( 'value' ) ).toBe( 'two' );
 		});
-
-		/*
-		selectFieldAttribute.options[''] = 'no value';
-		shortcodeData.attrs = [ selectFieldAttribute ];
-		shortcodeModel = new Shortcode( shortcodeData );
-
-		selectFieldModel = new ShortcodeAttribute(
-			shortcodeModel.get('attrs').models[0].attributes
-		);
-		selectFieldView = new EditAttributeField({ model: selectFieldModel });
-		selectFieldView.shortcode = shortcodeModel;
-
-		it( 'should allow an empty value, even when not the first option', function() {
-			selectFieldView.render();
-			expect( selectFieldModel.get( 'value' ) ).toBe( 'two' );
-
-		});
-		*/
 	});
 
 	describe( 'Select field with null attribute', function() {

--- a/js-tests/src/views/editAttributeFieldSpec.js
+++ b/js-tests/src/views/editAttributeFieldSpec.js
@@ -87,6 +87,56 @@ describe( 'Edit Attribute Field', function(){
 			selectFieldView.render();
 			expect( selectFieldModel.get( 'value' ) ).toBe( 'two' );
 		});
+
+		/*
+		selectFieldAttribute.options[''] = 'no value';
+		shortcodeData.attrs = [ selectFieldAttribute ];
+		shortcodeModel = new Shortcode( shortcodeData );
+
+		selectFieldModel = new ShortcodeAttribute(
+			shortcodeModel.get('attrs').models[0].attributes
+		);
+		selectFieldView = new EditAttributeField({ model: selectFieldModel });
+		selectFieldView.shortcode = shortcodeModel;
+
+		it( 'should allow an empty value, even when not the first option', function() {
+			selectFieldView.render();
+			expect( selectFieldModel.get( 'value' ) ).toBe( 'two' );
+
+		});
+		*/
+	});
+
+	describe( 'Select field with null attribute', function() {
+		var selectFieldAttribute, selectFieldView, selectFieldModel;
+
+		selectFieldAttribute = {
+			attr: 'select_field',
+			label: 'Select Attribute Field',
+			type: 'select',
+			options: {
+				one: 'one',
+				two: 'two',
+				'': 'no value',
+				three: 'three'
+			}
+		};
+
+		shortcodeData.attrs = [ selectFieldAttribute ];
+		shortcodeModel = new Shortcode( shortcodeData );
+
+		selectFieldModel = new ShortcodeAttribute(
+			shortcodeModel.get('attrs').models[0].attributes
+		);
+		selectFieldView = new EditAttributeField({ model: selectFieldModel });
+		selectFieldView.shortcode = shortcodeModel;
+		selectFieldView.template = selectFieldView.triggerCallbacks =  function( data ) {};
+		selectFieldView.template = function( data ) {};
+
+		it( 'should not use first option as the default if an empty option is set', function() {
+			selectFieldView.render();
+			expect( selectFieldModel.get( 'value' ) ).toBe( '' );
+		});
 	});
 
 });

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -1143,16 +1143,16 @@ var editAttributeField = Backbone.View.extend( {
 			data.options = this.parseOptions( data.options );
 		}
 
-		this.$el.html( this.template( data ) );
-
 		// Ensure default value for select field.
-		if ( 'select' === data.type && '' === this.model.get( 'value' ) ) {
+		if ( 'select' === data.type && '' === this.model.get( 'value' ) && ! _.findWhere( data.options, { value: '' } ) ) {
 			var firstVisibleOption = _.first( data.options );
 			if ( 'undefined' !== typeof firstVisibleOption.value ) {
 				this.setValue( firstVisibleOption.value );
+				data.value = firstVisibleOption.value;
 			}
 		}
 
+		this.$el.html( this.template( data ) );
 		this.triggerCallbacks();
 
 		return this;

--- a/js/src/views/edit-attribute-field.js
+++ b/js/src/views/edit-attribute-field.js
@@ -47,16 +47,16 @@ var editAttributeField = Backbone.View.extend( {
 			data.options = this.parseOptions( data.options );
 		}
 
-		this.$el.html( this.template( data ) );
-
 		// Ensure default value for select field.
-		if ( 'select' === data.type && '' === this.model.get( 'value' ) ) {
+		if ( 'select' === data.type && '' === this.model.get( 'value' ) && ! _.findWhere( data.options, { value: '' } ) ) {
 			var firstVisibleOption = _.first( data.options );
 			if ( 'undefined' !== typeof firstVisibleOption.value ) {
 				this.setValue( firstVisibleOption.value );
+				data.value = firstVisibleOption.value;
 			}
 		}
 
+		this.$el.html( this.template( data ) );
 		this.triggerCallbacks();
 
 		return this;


### PR DESCRIPTION
If an option with a null value is present, then let the field value
default to empty, rather than to the first visible option value. Also
sets that value on the data object so that it shows as visibly selected.

Merges into #673 