### PR TITLE
Add `send_to_editor` filter

### DIFF
--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -79,9 +79,7 @@ var MediaController = wp.media.controller.State.extend({
 		 * Filter run before a shortcode is sent to the editor. Can be used for
 		 * client-side validation before closing the media modal.
 		 *
-		 * Called as `shortcode_ui.send_to_editor`.
-		 *
-		 *
+		 * Called as `shortcode-ui.send_to_editor`.
 		 *
 		 * @param $.Deferred A promise which is expected to either resolve if
 		 *                   the shortcode can be sent to the editor, or reject
@@ -90,7 +88,7 @@ var MediaController = wp.media.controller.State.extend({
 		 */
 		var sendToEditor$ = wp.shortcake.hooks.applyFilters( 'shortcode-ui.send_to_editor', okToInsert$, shortcode );
 
-		// Unless a filter has ch, resolve the promise, sending the shortcode to the editor.
+		// Unless a filter has interfered, resolve the promise, sending the shortcode to the editor.
 		setTimeout( function() { okToInsert$.resolve(true); } );
 
 		sendToEditor$.then(

--- a/js/src/controllers/media-controller.js
+++ b/js/src/controllers/media-controller.js
@@ -1,4 +1,5 @@
 var Backbone = require('backbone'),
+	$ = require('jquery'),
     wp = require('wp'),
     sui = require('sui-utils/sui'),
     Shortcodes = require('sui-collections/shortcodes');
@@ -33,12 +34,35 @@ var MediaController = wp.media.controller.State.extend({
 	},
 
 	insert: function() {
+		var self = this;
 		var shortcode = this.props.get('currentShortcode');
-		if ( shortcode ) {
-			send_to_editor( shortcode.formatShortcode() );
-			this.reset();
-			this.frame.close();
-		}
+		var okToInsert$ = $.Deferred();
+
+		/*
+		 * Filter run before a shortcode is sent to the editor. Can be used for
+		 * client-side validation before closing the media modal.
+		 *
+		 * Called as `shortcode_ui.send_to_editor`.
+		 *
+		 *
+		 *
+		 * @param $.Deferred A promise which is expected to either resolve if
+		 *                   the shortcode can be sent to the editor, or reject
+		 *                   if not.
+		 * @param Shortcode  The current shortcode model.
+		 */
+		var sendToEditor$ = wp.shortcake.hooks.applyFilters( 'shortcode-ui.send_to_editor', okToInsert$, shortcode );
+
+		// Unless a filter has ch, resolve the promise, sending the shortcode to the editor.
+		setTimeout( function() { okToInsert$.resolve(true); } );
+
+		sendToEditor$.then(
+			function() {
+				send_to_editor( shortcode.formatShortcode() );
+				self.reset();
+				self.frame.close();
+			}
+		);
 	},
 
 	reset: function() {

--- a/js/src/controllers/media-controller.js
+++ b/js/src/controllers/media-controller.js
@@ -42,9 +42,7 @@ var MediaController = wp.media.controller.State.extend({
 		 * Filter run before a shortcode is sent to the editor. Can be used for
 		 * client-side validation before closing the media modal.
 		 *
-		 * Called as `shortcode_ui.send_to_editor`.
-		 *
-		 *
+		 * Called as `shortcode-ui.send_to_editor`.
 		 *
 		 * @param $.Deferred A promise which is expected to either resolve if
 		 *                   the shortcode can be sent to the editor, or reject
@@ -53,7 +51,7 @@ var MediaController = wp.media.controller.State.extend({
 		 */
 		var sendToEditor$ = wp.shortcake.hooks.applyFilters( 'shortcode-ui.send_to_editor', okToInsert$, shortcode );
 
-		// Unless a filter has ch, resolve the promise, sending the shortcode to the editor.
+		// Unless a filter has interfered, resolve the promise, sending the shortcode to the editor.
 		setTimeout( function() { okToInsert$.resolve(true); } );
 
 		sendToEditor$.then(


### PR DESCRIPTION
Adds a filter which can be used for client-side validation of a shortcode before sending it to the editor. Basic concept for addressing issue #615; for discussion only at this point. (I think this needs some
kind of syntactic sugar to help work with it, as the API this exposes doesn't follow any established conventions in the WP universe and isn't self-explanatory at all.)

@pySilver @marcin-lawrowski This seems like the bare minimum to make the use case you described in #615 possible. 

Hooking into this and blocking sending the shortcode to the editor would be a matter of returning a rejected promise from that filter, like this:

```
wp.shortcake.hooks.addFilter( 'shortcode-ui.send_to_editor', 
    function( okToSend$, shortcode ) {
        console.log( shortcode );
        okToSend$.reject();
        return okToSend$;
    }
);
```

Any thoughts on making this easier to work with? I like the idea of registering validation methods in the `shortcode_ui_register_for_shortcode` function, but I'm torn as to whether they belong on the attributes, the shortcode as a whole, or both.