### PR TITLE
Optionally set checkbox values as 'true' or 'false'

### DIFF
--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -458,7 +458,7 @@ class Shortcode_UI {
 				$out[ $attr['attr'] ] = rawurldecode( $out[ $attr['attr'] ] );
 			}
 
-			if ( $explicitbool && in_array( $out[ $attr['attr'] ], array( 'true', 'false' ) ) ) {
+			if ( $explicitbool && in_array( $out[ $attr['attr'] ], array( 'true', 'false' ), true ) ) {
 				$out[ $attr['attr'] ] = $this->explicitbool( $out[ $attr['attr'] ] );
 			}
 		}

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -427,7 +427,7 @@ class Shortcode_UI {
 	}
 
 	/**
-	 * Decode any encoded attributes.
+	 * Decode any encoded attributes, and convert true/false strings to their boolean equivalents.
 	 *
 	 * @param array $out   The output array of shortcode attributes.
 	 * @param array $pairs The supported attributes and their defaults.
@@ -452,8 +452,14 @@ class Shortcode_UI {
 			$default = isset( $fields[ $attr['type'] ]['encode'] ) ? $fields[ $attr['type'] ]['encode'] : false;
 			$encoded = isset( $attr['encode'] ) ? $attr['encode'] : $default;
 
+			$explictbool = isset( $attr['explicitbool'] ) ? $attr['explicitbool'] : false;
+
 			if ( $encoded && isset( $out[ $attr['attr'] ] ) ) {
 				$out[ $attr['attr'] ] = rawurldecode( $out[ $attr['attr'] ] );
+			}
+
+			if ( $explicitbool && in_array( $out[ $attr['attr'] ], array( 'true', 'false' ) ) ) {
+				$out[ $attr['attr'] ] = $this->explicitbool( $out[ $attr['attr'] ] );
 			}
 		}
 
@@ -461,4 +467,19 @@ class Shortcode_UI {
 
 	}
 
+	/**
+	 * Convert 'true' or 'false' strings to their boolean equivalent.
+	 *
+	 * @param string Expected to be either 'true' or 'false'
+	 * @return bool
+	 */
+	private function explicitbool( $bool_string ) {
+		if ( 'true' === $bool_string ) {
+			return true;
+		}
+		if ( 'false' === $bool_string ) {
+			return false;
+		}
+		return null;
+	}
 }

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -452,7 +452,7 @@ class Shortcode_UI {
 			$default = isset( $fields[ $attr['type'] ]['encode'] ) ? $fields[ $attr['type'] ]['encode'] : false;
 			$encoded = isset( $attr['encode'] ) ? $attr['encode'] : $default;
 
-			$explictbool = isset( $attr['explicitbool'] ) ? $attr['explicitbool'] : false;
+			$explicitbool = isset( $attr['explicitbool'] ) ? $attr['explicitbool'] : false;
 
 			if ( $encoded && isset( $out[ $attr['attr'] ] ) ) {
 				$out[ $attr['attr'] ] = rawurldecode( $out[ $attr['attr'] ] );

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -833,7 +833,12 @@ Shortcode = Backbone.Model.extend({
 
 		this.get( 'attrs' ).each( function( attr ) {
 
-			// Skip empty attributes.
+			// Send 'true' and 'false' as checkbox values if 'explicitbool' option is on
+			if ( attr.get( 'explicitbool' ) && 'boolean' === typeof attr.get( 'value' ) ) {
+				attr.set( 'value', attr.get( 'value' ) ? 'true' : 'false' );
+			}
+
+			// Otherwise, skip empty or false attributes.
 			if ( ! attr.get( 'value' ) ||  attr.get( 'value' ).length < 1 ) {
 				return;
 			}

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -204,7 +204,12 @@ Shortcode = Backbone.Model.extend({
 
 		this.get( 'attrs' ).each( function( attr ) {
 
-			// Skip empty attributes.
+			// Send 'true' and 'false' as checkbox values if 'explicitbool' option is on
+			if ( attr.get( 'explicitbool' ) && 'boolean' === typeof attr.get( 'value' ) ) {
+				attr.set( 'value', attr.get( 'value' ) ? 'true' : 'false' );
+			}
+
+			// Otherwise, skip empty or false attributes.
 			if ( ! attr.get( 'value' ) ||  attr.get( 'value' ).length < 1 ) {
 				return;
 			}

--- a/js/src/models/shortcode.js
+++ b/js/src/models/shortcode.js
@@ -68,7 +68,12 @@ Shortcode = Backbone.Model.extend({
 
 		this.get( 'attrs' ).each( function( attr ) {
 
-			// Skip empty attributes.
+			// Send 'true' and 'false' as checkbox values if 'explicitbool' option is on
+			if ( attr.get( 'explicitbool' ) && 'boolean' === typeof attr.get( 'value' ) ) {
+				attr.set( 'value', attr.get( 'value' ) ? 'true' : 'false' );
+			}
+
+			// Otherwise, skip empty or false attributes.
 			if ( ! attr.get( 'value' ) ||  attr.get( 'value' ).length < 1 ) {
 				return;
 			}


### PR DESCRIPTION
Adds the attribute option 'explicitbool' for checkboxes. If a checkbox is registered with 'explicitbool' => true, then the shortcode will be formatted with that attribute string like `attribute="false"` if unchecked. If the shortcode attributes are retrieved using the shortcode tag as the third parameter to `shortcode_atts()`, then this value will be converted back to a boolean automatically.

This allows better handling of default values for attributes - otherwise, if an attribute was set with a default value of "true", then even if it was unchecked, the next time the shortcode was opened to
edit, that default would be applied and the checkbox would be reset to checked.

Fixes #359, #550, and #564. Replaces #413.