### PR TITLE
Add node-sass as devDependency to fix grunt-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "grunt-sass": "^1.1.0",
     "grunt-wp-i18n": "^0.5.0",
     "grunt-wp-readme-to-markdown": "~1.0.0",
+    "node-sass": "^4.1.1",
     "remapify": "1.4.3"
   },
   "browserify": {


### PR DESCRIPTION
Fixes `grunt` builds. Without this I would get:

> Warning: Task "sass" not found. Use --force to continue.
> Error: Task "sass" not found.