### PR TITLE
Reset state instead of creating duplicate modals

### DIFF
--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -1181,6 +1181,11 @@ var shortcodeViewConstructor = {
 				});
 			}
 
+			// Make sure to reset state when closed.
+			frame.once( 'close submit', function() {
+				frame.setState( 'insert' );
+			} );
+
 			/* Trigger render_edit */
 			/*
 			 * Action run after an edit shortcode overlay is rendered.

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -1170,8 +1170,6 @@ var shortcodeViewConstructor = {
 
 			if ( frame ) {
 				frame.mediaController.setActionUpdate( currentShortcode );
-				frame.setState( 'shortcode-ui' );
-				frame.content.render();
 				frame.open();
 			} else {
 				frame = wp.media.editor.open( window.wpActiveEditor, {

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -1181,6 +1181,10 @@ var shortcodeViewConstructor = {
 
 			// Make sure to reset state when closed.
 			frame.once( 'close submit', function() {
+				frame.state().props.set('currentShortcode', false);
+				var menuItem = frame.menu.get().get('shortcode-ui');
+				menuItem.options.text = shortcodeUIData.strings.media_frame_title;
+				menuItem.render();
 				frame.setState( 'insert' );
 			} );
 

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -1166,13 +1166,20 @@ var shortcodeViewConstructor = {
 
 		if ( currentShortcode ) {
 
-			var wp_media_frame = wp.media.frames.wp_media_frame = wp.media({
-				frame : "post",
-				state : 'shortcode-ui',
-				currentShortcode : currentShortcode,
-			});
+			var frame = wp.media.editor.get( window.wpActiveEditor );
 
-			wp_media_frame.open();
+			if ( frame ) {
+				frame.mediaController.setActionUpdate( currentShortcode );
+				frame.setState( 'shortcode-ui' );
+				frame.content.render();
+				frame.open();
+			} else {
+				frame = wp.media.editor.open( window.wpActiveEditor, {
+					frame : "post",
+					state : 'shortcode-ui',
+					currentShortcode : currentShortcode,
+				});
+			}
 
 			/* Trigger render_edit */
 			/*

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -335,8 +335,13 @@ $(document).ready(function(){
 			frame.content.render();
 			frame.open();
 		} else {
-			wp.media.editor.open( editor, options );
+			frame = wp.media.editor.open( editor, options );
 		}
+
+		// Make sure to reset state when closed.
+		frame.once( 'close submit', function() {
+			frame.setState( 'insert' );
+		} );
 
 	} );
 
@@ -641,6 +646,11 @@ var shortcodeViewConstructor = {
 					currentShortcode : currentShortcode,
 				});
 			}
+
+			// Make sure to reset state when closed.
+			frame.once( 'close submit', function() {
+				frame.setState( 'insert' );
+			} );
 
 			/* Trigger render_edit */
 			/*
@@ -1527,7 +1537,6 @@ var mediaFrame = postMediaFrame.extend( {
 
 		this.on( 'content:render:' + id + '-content-insert', _.bind( this.contentRender, this, 'shortcode-ui', 'insert' ) );
 		this.on( 'toolbar:create:' + id + '-toolbar', this.toolbarCreate, this );
-		this.on( 'toolbar:render:' + id + '-toolbar', this.toolbarRender, this );
 		this.on( 'menu:render:default', this.renderShortcodeUIMenu );
 
 	},
@@ -1554,13 +1563,11 @@ var mediaFrame = postMediaFrame.extend( {
 		);
 	},
 
-	toolbarRender: function( toolbar ) {},
-
 	toolbarCreate : function( toolbar ) {
 
 		var text = shortcodeUIData.strings.media_frame_toolbar_insert_label;
 
-		if ( 'currentShortcode' in this.options ) {
+		if ( this.state().props.get('currentShortcode') ) {
 			text = shortcodeUIData.strings.media_frame_toolbar_update_label;
 		}
 

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -88,6 +88,14 @@ var MediaController = wp.media.controller.State.extend({
 		this.attributes.title = shortcodeUIData.strings.media_frame_menu_insert_label;
 		this.props.set( 'currentShortcode', null );
 		this.props.set( 'action', 'select' );
+
+		// Update menuItem text.
+		var menuItem = this.frame.menu.get().get('shortcode-ui');
+		menuItem.options.text = this.attributes.title;
+		menuItem.render();
+
+		this.frame.setState( 'shortcode-ui' );
+		this.frame.render();
 	},
 
 	setActionUpdate: function( currentShortcode ) {
@@ -101,6 +109,9 @@ var MediaController = wp.media.controller.State.extend({
 		// If a new frame is being created, it may not exist yet.
 		// Defer to ensure it does.
 		_.defer( function() {
+
+			this.frame.setState( 'shortcode-ui' );
+			this.frame.content.render();
 
 			this.toggleSidebar( true );
 
@@ -331,8 +342,6 @@ $(document).ready(function(){
 
 		if ( frame ) {
 			frame.mediaController.setActionSelect();
-			frame.setState( 'shortcode-ui' );
-			frame.content.render();
 			frame.open();
 		} else {
 			frame = wp.media.editor.open( editor, options );
@@ -636,8 +645,6 @@ var shortcodeViewConstructor = {
 
 			if ( frame ) {
 				frame.mediaController.setActionUpdate( currentShortcode );
-				frame.setState( 'shortcode-ui' );
-				frame.content.render();
 				frame.open();
 			} else {
 				frame = wp.media.editor.open( window.wpActiveEditor, {

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -349,6 +349,10 @@ $(document).ready(function(){
 
 		// Make sure to reset state when closed.
 		frame.once( 'close submit', function() {
+			frame.state().props.set('currentShortcode', false);
+			var menuItem = frame.menu.get().get('shortcode-ui');
+			menuItem.options.text = shortcodeUIData.strings.media_frame_title;
+			menuItem.render();
 			frame.setState( 'insert' );
 		} );
 
@@ -656,6 +660,10 @@ var shortcodeViewConstructor = {
 
 			// Make sure to reset state when closed.
 			frame.once( 'close submit', function() {
+				frame.state().props.set('currentShortcode', false);
+				var menuItem = frame.menu.get().get('shortcode-ui');
+				menuItem.options.text = shortcodeUIData.strings.media_frame_title;
+				menuItem.render();
 				frame.setState( 'insert' );
 			} );
 

--- a/js/src/controllers/media-controller.js
+++ b/js/src/controllers/media-controller.js
@@ -1,7 +1,7 @@
 var Backbone = require('backbone'),
-    wp = require('wp'),
-    sui = require('sui-utils/sui'),
-    Shortcodes = require('sui-collections/shortcodes');
+	wp = require('wp'),
+	sui = require('sui-utils/sui'),
+	Shortcodes = require('sui-collections/shortcodes');
 
 var MediaController = wp.media.controller.State.extend({
 
@@ -45,6 +45,38 @@ var MediaController = wp.media.controller.State.extend({
 		this.props.set( 'action', 'select' );
 		this.props.set( 'currentShortcode', null );
 		this.props.set( 'search', null );
+	},
+
+	setActionSelect: function() {
+		this.attributes.title = shortcodeUIData.strings.media_frame_menu_insert_label;
+		this.props.set( 'currentShortcode', null );
+		this.props.set( 'action', 'select' );
+	},
+
+	setActionUpdate: function( currentShortcode ) {
+
+		this.attributes.title = shortcodeUIData.strings.media_frame_menu_update_label;
+		this.attributes.title = this.attributes.title.replace( /%s/, currentShortcode.attributes.label );
+
+		this.props.set( 'currentShortcode', currentShortcode );
+		this.props.set( 'action', 'update' );
+
+		// If a new frame is being created, it may not exist yet.
+		// Defer to ensure it does.
+		_.defer( function() {
+
+			this.toggleSidebar( true );
+
+			this.frame.once( 'close', function() {
+				this.frame.mediaController.toggleSidebar( false );
+			}.bind( this ) );
+
+		}.bind( this ) );
+
+	},
+
+	toggleSidebar: function( show ) {
+		this.frame.$el.toggleClass( 'hide-menu', show );
 	},
 
 });

--- a/js/src/controllers/media-controller.js
+++ b/js/src/controllers/media-controller.js
@@ -51,6 +51,14 @@ var MediaController = wp.media.controller.State.extend({
 		this.attributes.title = shortcodeUIData.strings.media_frame_menu_insert_label;
 		this.props.set( 'currentShortcode', null );
 		this.props.set( 'action', 'select' );
+
+		// Update menuItem text.
+		var menuItem = this.frame.menu.get().get('shortcode-ui');
+		menuItem.options.text = this.attributes.title;
+		menuItem.render();
+
+		this.frame.setState( 'shortcode-ui' );
+		this.frame.render();
 	},
 
 	setActionUpdate: function( currentShortcode ) {
@@ -64,6 +72,9 @@ var MediaController = wp.media.controller.State.extend({
 		// If a new frame is being created, it may not exist yet.
 		// Defer to ensure it does.
 		_.defer( function() {
+
+			this.frame.setState( 'shortcode-ui' );
+			this.frame.content.render();
 
 			this.toggleSidebar( true );
 

--- a/js/src/shortcode-ui.js
+++ b/js/src/shortcode-ui.js
@@ -46,8 +46,13 @@ $(document).ready(function(){
 			frame.content.render();
 			frame.open();
 		} else {
-			wp.media.editor.open( editor, options );
+			frame = wp.media.editor.open( editor, options );
 		}
+
+		// Make sure to reset state when closed.
+		frame.once( 'close submit', function() {
+			frame.setState( 'insert' );
+		} );
 
 	} );
 

--- a/js/src/shortcode-ui.js
+++ b/js/src/shortcode-ui.js
@@ -23,8 +23,10 @@ $(document).ready(function(){
 	} );
 
 	$(document.body).on( 'click', '.shortcake-add-post-element', function( event ) {
-		var elem = $( event.currentTarget ),
-			editor = elem.data('editor'),
+
+		var $el     = $( event.currentTarget ),
+			editor  = $el.data('editor'),
+			frame   = wp.media.editor.get( editor ),
 			options = {
 				frame: 'post',
 				state: 'shortcode-ui',
@@ -35,12 +37,18 @@ $(document).ready(function(){
 
 		// Remove focus from the `.shortcake-add-post-element` button.
 		// Prevents Opera from showing the outline of the button above the modal.
-		//
 		// See: https://core.trac.wordpress.org/ticket/22445
-		elem.blur();
+		$el.blur();
 
-		wp.media.editor.remove( editor );
-		wp.media.editor.open( editor, options );
+		if ( frame ) {
+			frame.mediaController.setActionSelect();
+			frame.setState( 'shortcode-ui' );
+			frame.content.render();
+			frame.open();
+		} else {
+			wp.media.editor.open( editor, options );
+		}
+
 	} );
 
 });

--- a/js/src/shortcode-ui.js
+++ b/js/src/shortcode-ui.js
@@ -42,8 +42,6 @@ $(document).ready(function(){
 
 		if ( frame ) {
 			frame.mediaController.setActionSelect();
-			frame.setState( 'shortcode-ui' );
-			frame.content.render();
 			frame.open();
 		} else {
 			frame = wp.media.editor.open( editor, options );

--- a/js/src/shortcode-ui.js
+++ b/js/src/shortcode-ui.js
@@ -49,6 +49,10 @@ $(document).ready(function(){
 
 		// Make sure to reset state when closed.
 		frame.once( 'close submit', function() {
+			frame.state().props.set('currentShortcode', false);
+			var menuItem = frame.menu.get().get('shortcode-ui');
+			menuItem.options.text = shortcodeUIData.strings.media_frame_title;
+			menuItem.render();
 			frame.setState( 'insert' );
 		} );
 

--- a/js/src/utils/shortcode-view-constructor.js
+++ b/js/src/utils/shortcode-view-constructor.js
@@ -166,13 +166,20 @@ var shortcodeViewConstructor = {
 
 		if ( currentShortcode ) {
 
-			var wp_media_frame = wp.media.frames.wp_media_frame = wp.media({
-				frame : "post",
-				state : 'shortcode-ui',
-				currentShortcode : currentShortcode,
-			});
+			var frame = wp.media.editor.get( window.wpActiveEditor );
 
-			wp_media_frame.open();
+			if ( frame ) {
+				frame.mediaController.setActionUpdate( currentShortcode );
+				frame.setState( 'shortcode-ui' );
+				frame.content.render();
+				frame.open();
+			} else {
+				frame = wp.media.editor.open( window.wpActiveEditor, {
+					frame : "post",
+					state : 'shortcode-ui',
+					currentShortcode : currentShortcode,
+				});
+			}
 
 			/* Trigger render_edit */
 			/*

--- a/js/src/utils/shortcode-view-constructor.js
+++ b/js/src/utils/shortcode-view-constructor.js
@@ -181,6 +181,10 @@ var shortcodeViewConstructor = {
 
 			// Make sure to reset state when closed.
 			frame.once( 'close submit', function() {
+				frame.state().props.set('currentShortcode', false);
+				var menuItem = frame.menu.get().get('shortcode-ui');
+				menuItem.options.text = shortcodeUIData.strings.media_frame_title;
+				menuItem.render();
 				frame.setState( 'insert' );
 			} );
 

--- a/js/src/utils/shortcode-view-constructor.js
+++ b/js/src/utils/shortcode-view-constructor.js
@@ -181,6 +181,11 @@ var shortcodeViewConstructor = {
 				});
 			}
 
+			// Make sure to reset state when closed.
+			frame.once( 'close submit', function() {
+				frame.setState( 'insert' );
+			} );
+
 			/* Trigger render_edit */
 			/*
 			 * Action run after an edit shortcode overlay is rendered.

--- a/js/src/utils/shortcode-view-constructor.js
+++ b/js/src/utils/shortcode-view-constructor.js
@@ -170,8 +170,6 @@ var shortcodeViewConstructor = {
 
 			if ( frame ) {
 				frame.mediaController.setActionUpdate( currentShortcode );
-				frame.setState( 'shortcode-ui' );
-				frame.content.render();
 				frame.open();
 			} else {
 				frame = wp.media.editor.open( window.wpActiveEditor, {

--- a/js/src/views/media-frame.js
+++ b/js/src/views/media-frame.js
@@ -13,27 +13,20 @@ var mediaFrame = postMediaFrame.extend( {
 
 		var id = 'shortcode-ui';
 
-		var opts = {
-			id      : id,
-			search  : true,
-			router  : false,
-			toolbar : id + '-toolbar',
-			menu    : 'default',
-			title   : shortcodeUIData.strings.media_frame_menu_insert_label,
-			tabs    : [ 'insert' ],
-			priority:  66,
-			content : id + '-content-insert',
-		};
+		this.mediaController = new MediaController({
+			id       : id,
+			search   : true,
+			router   : false,
+			toolbar  : id + '-toolbar',
+			menu     : 'default',
+			title    : shortcodeUIData.strings.media_frame_menu_insert_label,
+			tabs     : [ 'insert' ],
+			priority :  66,
+			content  : id + '-content-insert',
+		});
 
 		if ( 'currentShortcode' in this.options ) {
-			opts.title = shortcodeUIData.strings.media_frame_menu_update_label.replace( /%s/, this.options.currentShortcode.attributes.label );
-		}
-
-		this.mediaController = new MediaController( opts );
-
-		if ( 'currentShortcode' in this.options ) {
-			this.mediaController.props.set( 'currentShortcode', arguments[0].currentShortcode );
-			this.mediaController.props.set( 'action', 'update' );
+			this.mediaController.setActionUpdate( this.options.currentShortcode );
 		}
 
 		this.states.add([ this.mediaController ]);
@@ -47,7 +40,7 @@ var mediaFrame = postMediaFrame.extend( {
 
 	events: function() {
 		return _.extend( {}, postMediaFrame.prototype.events, {
-			'click .media-menu-item'    : 'resetMediaController',
+			'click .media-menu-item' : 'resetMediaController',
 		} );
 	},
 
@@ -70,12 +63,14 @@ var mediaFrame = postMediaFrame.extend( {
 	toolbarRender: function( toolbar ) {},
 
 	toolbarCreate : function( toolbar ) {
+
 		var text = shortcodeUIData.strings.media_frame_toolbar_insert_label;
+
 		if ( 'currentShortcode' in this.options ) {
 			text = shortcodeUIData.strings.media_frame_toolbar_update_label;
 		}
 
-		toolbar.view = new  Toolbar( {
+		toolbar.view = new Toolbar( {
 			controller : this,
 			items: {
 				insert: {
@@ -98,17 +93,6 @@ var mediaFrame = postMediaFrame.extend( {
 				priority: 65
 			})
 		});
-
-		// Hide menu if editing.
-		// @todo - fix this.
-		// This is a hack.
-		// I just can't work out how to do it properly...
-		if ( view.controller.state().props && view.controller.state().props.get( 'currentShortcode' ) ) {
-			window.setTimeout( function() {
-				view.controller.$el.addClass( 'hide-menu' );
-			} );
-		}
-
 	},
 
 	insertAction: function() {

--- a/js/src/views/media-frame.js
+++ b/js/src/views/media-frame.js
@@ -33,7 +33,6 @@ var mediaFrame = postMediaFrame.extend( {
 
 		this.on( 'content:render:' + id + '-content-insert', _.bind( this.contentRender, this, 'shortcode-ui', 'insert' ) );
 		this.on( 'toolbar:create:' + id + '-toolbar', this.toolbarCreate, this );
-		this.on( 'toolbar:render:' + id + '-toolbar', this.toolbarRender, this );
 		this.on( 'menu:render:default', this.renderShortcodeUIMenu );
 
 	},
@@ -60,13 +59,11 @@ var mediaFrame = postMediaFrame.extend( {
 		);
 	},
 
-	toolbarRender: function( toolbar ) {},
-
 	toolbarCreate : function( toolbar ) {
 
 		var text = shortcodeUIData.strings.media_frame_toolbar_insert_label;
 
-		if ( 'currentShortcode' in this.options ) {
+		if ( this.state().props.get('currentShortcode') ) {
 			text = shortcodeUIData.strings.media_frame_toolbar_update_label;
 		}
 

--- a/js/src/views/shortcode-ui.js
+++ b/js/src/views/shortcode-ui.js
@@ -82,7 +82,7 @@ var Shortcode_UI = Backbone.View.extend({
 	},
 
 	select: function(e) {
-		this.controller.props.set( 'action', 'insert' );
+
 		var target    = $(e.currentTarget).closest( '.shortcode-list-item' );
 		var shortcode = sui.shortcodes.findWhere( { shortcode_tag: target.attr( 'data-shortcode' ) } );
 
@@ -90,6 +90,7 @@ var Shortcode_UI = Backbone.View.extend({
 			return;
 		}
 
+		this.controller.props.set( 'action', 'insert' );
 		this.controller.props.set( 'currentShortcode', shortcode.clone() );
 
 		this.render();


### PR DESCRIPTION
I have picked up the work started by @rahulsprajapati over here: https://github.com/wp-shortcake/shortcake/pull/680/files. This is a tricky problem, but one that we should definitely try and fix.

I tested his code, but I was still seeing some duplicate markup - as you said when clicking the standard add media button instead.

This fix takes a slightly different approach. Instead it tries to always use the same media modal. If it doesn't exist, it creates it. If it does, it updates the state of the existing one. Additionally I had to do a bit of work to reset the state too, to ensure that when a user clicks a button again, they do not see the old state. I guess we avoided this issue before because it just created a new instance of the modal!

I'd appreciate your thoughts on this.