### PR TITLE
Fix CI errors

### DIFF
--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -248,7 +248,8 @@ class Shortcode_UI {
 			'strings'         => array(
 				'media_frame_title'                 => __( 'Insert Post Element', 'shortcode-ui' ),
 				'media_frame_menu_insert_label'     => __( 'Insert Post Element', 'shortcode-ui' ),
-				'media_frame_menu_update_label'     => __( '%s Details', 'shortcode-ui' ), // Substituted in JS
+				/* Translators: Ignore placeholder. This is replaced with the Shortcode name string in JS */
+				'media_frame_menu_update_label'     => __( '%s Details', 'shortcode-ui' ),
 				'media_frame_toolbar_insert_label'  => __( 'Insert Element', 'shortcode-ui' ),
 				'media_frame_toolbar_update_label'  => __( 'Update', 'shortcode-ui' ),
 				'media_frame_no_attributes_message' => __( 'There are no attributes to configure for this Post Element.', 'shortcode-ui' ),

--- a/shortcode-ui.php
+++ b/shortcode-ui.php
@@ -62,13 +62,14 @@ function shortcode_ui_load_textdomain() {
 	$path = dirname( __FILE__ ) . '/languages';
 	// Load the textdomain according to the plugin first
 	$mofile = $domain . '-' . $locale . '.mo';
-	if ( $loaded = load_textdomain( $domain, $path . '/' . $mofile ) ) {
-		return;
+	$loaded = load_textdomain( $domain, $path . '/' . $mofile );
+
+	// If not loaded, load from the languages directory
+	if ( ! $loaded ) {
+		$mofile = WP_LANG_DIR . '/plugins/' . $mofile;
+		load_textdomain( $domain, $mofile );
 	}
 
-	// Otherwise, load from the languages directory
-	$mofile = WP_LANG_DIR . '/plugins/' . $mofile;
-	load_textdomain( $domain, $mofile );
 }
 
 /**


### PR DESCRIPTION
Travis is failing new PR's due to PHP codesniffer errors. I think they're new rules introduced in the latest version of the WPCS.

This should fix them.