### PR TITLE
Re-add deprecated function `editAttributeFieldAttachment.getFromCache`

### DIFF
--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -724,6 +724,8 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 
 		self.initSelection();
 
+		self.currentSelection.on( 'all', this.updateCache );
+
 		self.currentSelection.on( 'all', this.updateValue );
 		self.currentSelection.on( 'add', this._renderPreview );
 		self.currentSelection.on( 'reset', this._renderAll );
@@ -754,12 +756,26 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 
 			this.currentSelection.add( model );
 
-			// Re-render after attachments have synced.
+			// Re-render after attachments have synced, and add to cache.
 			model.fetch();
 			model.on( 'sync', this._renderAll );
 
 		}.bind(this) );
 
+	},
+
+	/**
+	 * Updates any fetched attachment models in the class attachment cache.
+	 *
+	 * This cache is exposed for convenience in listener functions that need to
+	 * access fields from it.
+	 *
+	 * @return null
+	 */
+	updateCache: function() {
+		_.each( this.currentSelection.models, function( model ) {
+			editAttributeFieldAttachment.addToCache( model.attributes.id, model.attributes );
+		} );
 	},
 
 	/**
@@ -907,6 +923,37 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 			this.currentSelection.remove( target );
 		}
 
+	},
+
+}, {
+
+	_idCache: {},
+
+	/**
+	 * Set a fetched attachment model in the _idCache lookup.
+	 *
+	 * @param int Attachment ID
+	 * @param {Object} attachment model attributes
+	 */
+	addToCache: function( id, attachment ) {
+		this._idCache[ id ] = attachment;
+	},
+
+	/**
+	 * Get an attachment model from the _idCache lookup.
+	 *
+	 * Prior to 0.7.0, this method was exposed as a public class
+	 * method and used internally to get attachment details from the `_idCache`
+	 * store.
+	 *
+	 * @deprecated Not used internally since 0.7.0
+	 */
+	getFromCache: function( id ) {
+		if ( 'undefined' === typeof this._idCache[ id ] ) {
+			return false;
+		}
+
+		return this._idCache[ id ];
 	},
 
 });

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -724,8 +724,6 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 
 		self.initSelection();
 
-		self.currentSelection.on( 'all', this.updateCache );
-
 		self.currentSelection.on( 'all', this.updateValue );
 		self.currentSelection.on( 'add', this._renderPreview );
 		self.currentSelection.on( 'reset', this._renderAll );
@@ -788,6 +786,7 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 	updateValue: function() {
 		var value = this.currentSelection.pluck( 'id' );
 		this.setValue( value );
+		this.updateCache();
 		this.triggerCallbacks();
 	},
 

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -763,20 +763,6 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 	},
 
 	/**
-	 * Updates any fetched attachment models in the class attachment cache.
-	 *
-	 * This cache is exposed for convenience in listener functions that need to
-	 * access fields from it.
-	 *
-	 * @return null
-	 */
-	updateCache: function() {
-		_.each( this.currentSelection.models, function( model ) {
-			editAttributeFieldAttachment.addToCache( model.attributes.id, model.attributes );
-		} );
-	},
-
-	/**
 	 * Update the field attachment.
 	 * Re-renders UI.
 	 * If ID is empty - does nothing.
@@ -786,7 +772,6 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 	updateValue: function() {
 		var value = this.currentSelection.pluck( 'id' );
 		this.setValue( value );
-		this.updateCache();
 		this.triggerCallbacks();
 	},
 
@@ -926,33 +911,20 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 
 }, {
 
-	_idCache: {},
-
 	/**
-	 * Set a fetched attachment model in the _idCache lookup.
-	 *
-	 * @param int Attachment ID
-	 * @param {Object} attachment model attributes
-	 */
-	addToCache: function( id, attachment ) {
-		this._idCache[ id ] = attachment;
-	},
-
-	/**
-	 * Get an attachment model from the _idCache lookup.
+	 * Get the Backbone model attributes of an attachment.
 	 *
 	 * Prior to 0.7.0, this method was exposed as a public class
-	 * method and used internally to get attachment details from the `_idCache`
-	 * store.
+	 * method and used internally to get attachment details from
+	 * the `_idCache` store.
 	 *
 	 * @deprecated Not used internally since 0.7.0
 	 */
 	getFromCache: function( id ) {
-		if ( 'undefined' === typeof this._idCache[ id ] ) {
-			return false;
+		if ( wp.media.attachment( id ) ) {
+			return wp.media.attachment( id ).attributes;
 		}
-
-		return this._idCache[ id ];
+		return false;
 	},
 
 });

--- a/js/src/views/edit-attribute-field-attachment.js
+++ b/js/src/views/edit-attribute-field-attachment.js
@@ -22,8 +22,6 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 
 		self.initSelection();
 
-		self.currentSelection.on( 'all', this.updateCache );
-
 		self.currentSelection.on( 'all', this.updateValue );
 		self.currentSelection.on( 'add', this._renderPreview );
 		self.currentSelection.on( 'reset', this._renderAll );
@@ -86,6 +84,7 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 	updateValue: function() {
 		var value = this.currentSelection.pluck( 'id' );
 		this.setValue( value );
+		this.updateCache();
 		this.triggerCallbacks();
 	},
 

--- a/js/src/views/edit-attribute-field-attachment.js
+++ b/js/src/views/edit-attribute-field-attachment.js
@@ -22,6 +22,8 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 
 		self.initSelection();
 
+		self.currentSelection.on( 'all', this.updateCache );
+
 		self.currentSelection.on( 'all', this.updateValue );
 		self.currentSelection.on( 'add', this._renderPreview );
 		self.currentSelection.on( 'reset', this._renderAll );
@@ -52,12 +54,26 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 
 			this.currentSelection.add( model );
 
-			// Re-render after attachments have synced.
+			// Re-render after attachments have synced, and add to cache.
 			model.fetch();
 			model.on( 'sync', this._renderAll );
 
 		}.bind(this) );
 
+	},
+
+	/**
+	 * Updates any fetched attachment models in the class attachment cache.
+	 *
+	 * This cache is exposed for convenience in listener functions that need to
+	 * access fields from it.
+	 *
+	 * @return null
+	 */
+	updateCache: function() {
+		_.each( this.currentSelection.models, function( model ) {
+			editAttributeFieldAttachment.addToCache( model.attributes.id, model.attributes );
+		} );
 	},
 
 	/**
@@ -205,6 +221,37 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 			this.currentSelection.remove( target );
 		}
 
+	},
+
+}, {
+
+	_idCache: {},
+
+	/**
+	 * Set a fetched attachment model in the _idCache lookup.
+	 *
+	 * @param int Attachment ID
+	 * @param {Object} attachment model attributes
+	 */
+	addToCache: function( id, attachment ) {
+		this._idCache[ id ] = attachment;
+	},
+
+	/**
+	 * Get an attachment model from the _idCache lookup.
+	 *
+	 * Prior to 0.7.0, this method was exposed as a public class
+	 * method and used internally to get attachment details from the `_idCache`
+	 * store.
+	 *
+	 * @deprecated Not used internally since 0.7.0
+	 */
+	getFromCache: function( id ) {
+		if ( 'undefined' === typeof this._idCache[ id ] ) {
+			return false;
+		}
+
+		return this._idCache[ id ];
 	},
 
 });

--- a/js/src/views/edit-attribute-field-attachment.js
+++ b/js/src/views/edit-attribute-field-attachment.js
@@ -61,20 +61,6 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 	},
 
 	/**
-	 * Updates any fetched attachment models in the class attachment cache.
-	 *
-	 * This cache is exposed for convenience in listener functions that need to
-	 * access fields from it.
-	 *
-	 * @return null
-	 */
-	updateCache: function() {
-		_.each( this.currentSelection.models, function( model ) {
-			editAttributeFieldAttachment.addToCache( model.attributes.id, model.attributes );
-		} );
-	},
-
-	/**
 	 * Update the field attachment.
 	 * Re-renders UI.
 	 * If ID is empty - does nothing.
@@ -84,7 +70,6 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 	updateValue: function() {
 		var value = this.currentSelection.pluck( 'id' );
 		this.setValue( value );
-		this.updateCache();
 		this.triggerCallbacks();
 	},
 
@@ -224,33 +209,20 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 
 }, {
 
-	_idCache: {},
-
 	/**
-	 * Set a fetched attachment model in the _idCache lookup.
-	 *
-	 * @param int Attachment ID
-	 * @param {Object} attachment model attributes
-	 */
-	addToCache: function( id, attachment ) {
-		this._idCache[ id ] = attachment;
-	},
-
-	/**
-	 * Get an attachment model from the _idCache lookup.
+	 * Get the Backbone model attributes of an attachment.
 	 *
 	 * Prior to 0.7.0, this method was exposed as a public class
-	 * method and used internally to get attachment details from the `_idCache`
-	 * store.
+	 * method and used internally to get attachment details from
+	 * the `_idCache` store.
 	 *
 	 * @deprecated Not used internally since 0.7.0
 	 */
 	getFromCache: function( id ) {
-		if ( 'undefined' === typeof this._idCache[ id ] ) {
-			return false;
+		if ( wp.media.attachment( id ) ) {
+			return wp.media.attachment( id ).attributes;
 		}
-
-		return this._idCache[ id ];
+		return false;
 	},
 
 });


### PR DESCRIPTION
Up until #508, we had a public class method exposed on `editAttributeFieldAttachment` called `getFromCache()`, which was being used elsewhere to hook into attachment preview rendering and other useful attachment needs. (For example, the Image Shortcake plugin [uses it to pull alt, caption, and other values from the attachment](https://github.com/wp-shortcake/image-shortcake/blob/ae5170965db0dacd5ce89d6558f26045e1cc3834/assets/js/image-shortcake-admin.js#L57) and prepopulate those fields on the image shortcode.)

I think it would still be helpful to expose this cache, even though it isn't needed anymore internally, just because it costs next to nothing to have in place, and is useful for integration with other fields.