### PR TITLE
Optional compatibility with other Select2 v3 plugins

### DIFF
--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -38,7 +38,7 @@ class Shortcode_UI {
 	private static $instance;
 
 	/**
-	 * Select2 handle
+	 * Select2 library handle.
 	 *
 	 * @access public
 	 * @var string
@@ -67,10 +67,6 @@ class Shortcode_UI {
 		$this->plugin_version = SHORTCODE_UI_VERSION;
 		$this->plugin_dir     = plugin_dir_path( dirname( __FILE__ ) );
 		$this->plugin_url     = plugin_dir_url( dirname( __FILE__ ) );
-
-		if(defined( 'SELECT2_NOCONFLICT' ) && SELECT2_NOCONFLICT){
-			self::$select2_handle = 'select2v4';
-		}
 	}
 
 	/**

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -198,14 +198,14 @@ class Shortcode_UI {
 		add_editor_style( trailingslashit( $this->plugin_url ) . 'css/shortcode-ui-editor-styles.css' );
 
 		$min = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
-		$noconflict = defined('SELECT2_NOCONFLICT') && SELECT2_NOCONFLICT;
+		$noconflict = defined( 'SELECT2_NOCONFLICT' ) && SELECT2_NOCONFLICT;
 
 		wp_register_script( $noconflict ? 'select2v4' : 'select2',
 			trailingslashit( $this->plugin_url ) . "lib/select2/js/select2.full{$min}.js",
 			array( 'jquery', 'jquery-ui-sortable' ), '4.0.3'
 		);
 
-		if($noconflict){
+		if( $noconflict ){
 			 wp_add_inline_script( 'select2v4', 'var existingSelect2 = jQuery.fn.select2 || null; if (existingSelect2) { delete jQuery.fn.select2; }', 'before' );
 			 wp_add_inline_script( 'select2v4', 'jQuery.fn.select2v4 = jQuery.fn.select2; if (existingSelect2) { delete jQuery.fn.select2; jQuery.fn.select2 = existingSelect2; }', 'after' );
 		}

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -198,13 +198,19 @@ class Shortcode_UI {
 		add_editor_style( trailingslashit( $this->plugin_url ) . 'css/shortcode-ui-editor-styles.css' );
 
 		$min = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
+		$noconflict = defined('SELECT2_NOCONFLICT') && SELECT2_NOCONFLICT;
 
-		wp_register_script( 'select2',
+		wp_register_script( $noconflict ? 'select2v4' : 'select2',
 			trailingslashit( $this->plugin_url ) . "lib/select2/js/select2.full{$min}.js",
 			array( 'jquery', 'jquery-ui-sortable' ), '4.0.3'
 		);
 
-		wp_register_style( 'select2',
+		if($noconflict){
+			 wp_add_inline_script( 'select2v4', 'var existingSelect2 = jQuery.fn.select2 || null; if (existingSelect2) { delete jQuery.fn.select2; }', 'before' );
+			 wp_add_inline_script( 'select2v4', 'jQuery.fn.select2v4 = jQuery.fn.select2; if (existingSelect2) { delete jQuery.fn.select2; jQuery.fn.select2 = existingSelect2; }', 'after' );
+		}
+
+		wp_register_style( $noconflict ? 'select2v4' : 'select2',
 			trailingslashit( $this->plugin_url ) . "lib/select2/css/select2{$min}.css",
 			null, '4.0.3'
 		);

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -214,7 +214,7 @@ class Shortcode_UI {
 
 		if( self::$select2_handle !== 'select2' ){
 			 wp_add_inline_script( self::$select2_handle, 'var existingSelect2 = jQuery.fn.select2 || null; if (existingSelect2) { delete jQuery.fn.select2; }', 'before' );
-			 wp_add_inline_script( self::$select2_handle, 'jQuery.fn.'.self::$select2_handle.' = jQuery.fn.select2; if (existingSelect2) { delete jQuery.fn.select2; jQuery.fn.select2 = existingSelect2; }', 'after' );
+			 wp_add_inline_script( self::$select2_handle, 'jQuery.fn[ shortcodeUIData.select2_handle ] = jQuery.fn.select2; if (existingSelect2) { delete jQuery.fn.select2; jQuery.fn.select2 = existingSelect2; }', 'after' );
 		}
 
 		wp_register_style( self::$select2_handle,

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -38,6 +38,14 @@ class Shortcode_UI {
 	private static $instance;
 
 	/**
+	 * Select2 handle
+	 *
+	 * @access public
+	 * @var string
+	 */
+	public static $select2_handle = 'select2';
+
+	/**
 	 * Get instance of Shortcake controller.
 	 *
 	 * Instantiates object on the fly when not already loaded.
@@ -59,6 +67,10 @@ class Shortcode_UI {
 		$this->plugin_version = SHORTCODE_UI_VERSION;
 		$this->plugin_dir     = plugin_dir_path( dirname( __FILE__ ) );
 		$this->plugin_url     = plugin_dir_url( dirname( __FILE__ ) );
+
+		if(defined( 'SELECT2_NOCONFLICT' ) && SELECT2_NOCONFLICT){
+			self::$select2_handle = 'select2v4';
+		}
 	}
 
 	/**
@@ -198,19 +210,18 @@ class Shortcode_UI {
 		add_editor_style( trailingslashit( $this->plugin_url ) . 'css/shortcode-ui-editor-styles.css' );
 
 		$min = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
-		$noconflict = defined( 'SELECT2_NOCONFLICT' ) && SELECT2_NOCONFLICT;
 
-		wp_register_script( $noconflict ? 'select2v4' : 'select2',
+		wp_register_script( self::$select2_handle,
 			trailingslashit( $this->plugin_url ) . "lib/select2/js/select2.full{$min}.js",
 			array( 'jquery', 'jquery-ui-sortable' ), '4.0.3'
 		);
 
-		if( $noconflict ){
-			 wp_add_inline_script( 'select2v4', 'var existingSelect2 = jQuery.fn.select2 || null; if (existingSelect2) { delete jQuery.fn.select2; }', 'before' );
-			 wp_add_inline_script( 'select2v4', 'jQuery.fn.select2v4 = jQuery.fn.select2; if (existingSelect2) { delete jQuery.fn.select2; jQuery.fn.select2 = existingSelect2; }', 'after' );
+		if( self::$select2_handle !== 'select2' ){
+			 wp_add_inline_script( self::$select2_handle, 'var existingSelect2 = jQuery.fn.select2 || null; if (existingSelect2) { delete jQuery.fn.select2; }', 'before' );
+			 wp_add_inline_script( self::$select2_handle, 'jQuery.fn.'.self::$select2_handle.' = jQuery.fn.select2; if (existingSelect2) { delete jQuery.fn.select2; jQuery.fn.select2 = existingSelect2; }', 'after' );
 		}
 
-		wp_register_style( $noconflict ? 'select2v4' : 'select2',
+		wp_register_style( self::$select2_handle,
 			trailingslashit( $this->plugin_url ) . "lib/select2/css/select2{$min}.css",
 			null, '4.0.3'
 		);
@@ -267,6 +278,7 @@ class Shortcode_UI {
 				'preview'        => wp_create_nonce( 'shortcode-ui-preview' ),
 				'thumbnailImage' => wp_create_nonce( 'shortcode-ui-get-thumbnail-image' ),
 			),
+			'select2_handle' => self::$select2_handle
 		) );
 
 		// add templates to the footer, instead of where we're at now

--- a/inc/fields/class-field-post-select.php
+++ b/inc/fields/class-field-post-select.php
@@ -38,8 +38,10 @@ class Shortcode_UI_Field_Post_Select {
 
 	public function action_enqueue_shortcode_ui() {
 
-		wp_enqueue_script( 'select2' );
-		wp_enqueue_style( 'select2' );
+		$noconflict = defined('SELECT2_NOCONFLICT') && SELECT2_NOCONFLICT;
+
+		wp_enqueue_script(  $noconflict ? 'select2v4' : 'select2' );
+		wp_enqueue_style(  $noconflict ? 'select2v4' : 'select2' );
 
 		wp_localize_script( 'shortcode-ui', 'shortcodeUiPostFieldData', array(
 			'nonce' => wp_create_nonce( 'shortcode_ui_field_post_select' ),

--- a/inc/fields/class-field-post-select.php
+++ b/inc/fields/class-field-post-select.php
@@ -38,10 +38,10 @@ class Shortcode_UI_Field_Post_Select {
 
 	public function action_enqueue_shortcode_ui() {
 
-		$noconflict = defined('SELECT2_NOCONFLICT') && SELECT2_NOCONFLICT;
+		$noconflict = defined( 'SELECT2_NOCONFLICT' ) && SELECT2_NOCONFLICT;
 
-		wp_enqueue_script(  $noconflict ? 'select2v4' : 'select2' );
-		wp_enqueue_style(  $noconflict ? 'select2v4' : 'select2' );
+		wp_enqueue_script( $noconflict ? 'select2v4' : 'select2' );
+		wp_enqueue_style( $noconflict ? 'select2v4' : 'select2' );
 
 		wp_localize_script( 'shortcode-ui', 'shortcodeUiPostFieldData', array(
 			'nonce' => wp_create_nonce( 'shortcode_ui_field_post_select' ),

--- a/inc/fields/class-field-post-select.php
+++ b/inc/fields/class-field-post-select.php
@@ -38,10 +38,8 @@ class Shortcode_UI_Field_Post_Select {
 
 	public function action_enqueue_shortcode_ui() {
 
-		$noconflict = defined( 'SELECT2_NOCONFLICT' ) && SELECT2_NOCONFLICT;
-
-		wp_enqueue_script( $noconflict ? 'select2v4' : 'select2' );
-		wp_enqueue_style( $noconflict ? 'select2v4' : 'select2' );
+		wp_enqueue_script( Shortcode_UI::$select2_handle );
+		wp_enqueue_style( Shortcode_UI::$select2_handle );
 
 		wp_localize_script( 'shortcode-ui', 'shortcodeUiPostFieldData', array(
 			'nonce' => wp_create_nonce( 'shortcode_ui_field_post_select' ),

--- a/inc/fields/class-field-term-select.php
+++ b/inc/fields/class-field-term-select.php
@@ -52,8 +52,10 @@ class Shortcode_UI_Field_Term_Select {
 	 */
 	public function action_enqueue_shortcode_ui() {
 
-		wp_enqueue_script( 'select2' );
-		wp_enqueue_style( 'select2' );
+		$noconflict = defined('SELECT2_NOCONFLICT') && SELECT2_NOCONFLICT;
+		
+		wp_enqueue_script( $noconflict ? 'select2v4' : 'select2' );
+		wp_enqueue_style(  $noconflict ? 'select2v4' : 'select2' );
 
 		wp_localize_script( 'shortcode-ui', 'shortcodeUiTermFieldData', array(
 			'nonce' => wp_create_nonce( 'shortcode_ui_field_term_select' ),

--- a/inc/fields/class-field-term-select.php
+++ b/inc/fields/class-field-term-select.php
@@ -52,10 +52,8 @@ class Shortcode_UI_Field_Term_Select {
 	 */
 	public function action_enqueue_shortcode_ui() {
 
-		$noconflict = defined( 'SELECT2_NOCONFLICT' ) && SELECT2_NOCONFLICT;
-
-		wp_enqueue_script( $noconflict ? 'select2v4' : 'select2' );
-		wp_enqueue_style( $noconflict ? 'select2v4' : 'select2' );
+		wp_enqueue_script( Shortcode_UI::$select2_handle );
+		wp_enqueue_style( Shortcode_UI::$select2_handle );
 
 		wp_localize_script( 'shortcode-ui', 'shortcodeUiTermFieldData', array(
 			'nonce' => wp_create_nonce( 'shortcode_ui_field_term_select' ),

--- a/inc/fields/class-field-term-select.php
+++ b/inc/fields/class-field-term-select.php
@@ -52,10 +52,10 @@ class Shortcode_UI_Field_Term_Select {
 	 */
 	public function action_enqueue_shortcode_ui() {
 
-		$noconflict = defined('SELECT2_NOCONFLICT') && SELECT2_NOCONFLICT;
-		
+		$noconflict = defined( 'SELECT2_NOCONFLICT' ) && SELECT2_NOCONFLICT;
+
 		wp_enqueue_script( $noconflict ? 'select2v4' : 'select2' );
-		wp_enqueue_style(  $noconflict ? 'select2v4' : 'select2' );
+		wp_enqueue_style( $noconflict ? 'select2v4' : 'select2' );
 
 		wp_localize_script( 'shortcode-ui', 'shortcodeUiTermFieldData', array(
 			'nonce' => wp_create_nonce( 'shortcode_ui_field_term_select' ),

--- a/inc/fields/class-field-user-select.php
+++ b/inc/fields/class-field-user-select.php
@@ -58,10 +58,8 @@ class Shortcode_UI_Field_User_Select {
 	 */
 	public function action_enqueue_shortcode_ui() {
 
-		$noconflict = defined( 'SELECT2_NOCONFLICT' ) && SELECT2_NOCONFLICT;
-
-		wp_enqueue_script( $noconflict ? 'select2v4' : 'select2' );
-		wp_enqueue_style( $noconflict ? 'select2v4' : 'select2' );
+		wp_enqueue_script( Shortcode_UI::$select2_handle );
+		wp_enqueue_style( Shortcode_UI::$select2_handle );
 
 		wp_localize_script( 'shortcode-ui', 'shortcodeUiUserFieldData', array(
 			'nonce' => wp_create_nonce( 'shortcode_ui_field_user_select' ),

--- a/inc/fields/class-field-user-select.php
+++ b/inc/fields/class-field-user-select.php
@@ -58,8 +58,10 @@ class Shortcode_UI_Field_User_Select {
 	 */
 	public function action_enqueue_shortcode_ui() {
 
-		wp_enqueue_script( 'select2' );
-		wp_enqueue_style( 'select2' );
+		$noconflict = defined('SELECT2_NOCONFLICT') && SELECT2_NOCONFLICT;
+
+		wp_enqueue_script(  $noconflict ? 'select2v4' : 'select2' );
+		wp_enqueue_style(  $noconflict ? 'select2v4' : 'select2' );
 
 		wp_localize_script( 'shortcode-ui', 'shortcodeUiUserFieldData', array(
 			'nonce' => wp_create_nonce( 'shortcode_ui_field_user_select' ),

--- a/inc/fields/class-field-user-select.php
+++ b/inc/fields/class-field-user-select.php
@@ -58,10 +58,10 @@ class Shortcode_UI_Field_User_Select {
 	 */
 	public function action_enqueue_shortcode_ui() {
 
-		$noconflict = defined('SELECT2_NOCONFLICT') && SELECT2_NOCONFLICT;
+		$noconflict = defined( 'SELECT2_NOCONFLICT' ) && SELECT2_NOCONFLICT;
 
-		wp_enqueue_script(  $noconflict ? 'select2v4' : 'select2' );
-		wp_enqueue_style(  $noconflict ? 'select2v4' : 'select2' );
+		wp_enqueue_script( $noconflict ? 'select2v4' : 'select2' );
+		wp_enqueue_style( $noconflict ? 'select2v4' : 'select2' );
 
 		wp_localize_script( 'shortcode-ui', 'shortcodeUiUserFieldData', array(
 			'nonce' => wp_create_nonce( 'shortcode_ui_field_user_select' ),

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -1768,7 +1768,8 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 
 		this.preselect( $field );
 
-		var $fieldSelect2 = $field.select2({
+                var select2 = jQuery().select2v4 ? 'select2v4' : 'select2';
+                var $fieldSelect2 = $field[select2]({
 			placeholder: "Search",
 			multiple: this.model.get( 'multiple' ),
 
@@ -1834,7 +1835,8 @@ sui.controllers.MediaController = mediaController.extend({
 	},
 
 	destroySelect2UI: function() {
-		$fieldSelect2.select2( 'close' );
+                var select2 = jQuery().select2v4 ? 'select2v4' : 'select2';
+                $fieldSelect2[select2]( 'close' );
 	}
 
 });

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -1768,8 +1768,7 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 
 		this.preselect( $field );
 
-                var select2 = jQuery().select2v4 ? 'select2v4' : 'select2';
-                var $fieldSelect2 = $field[select2]({
+                var $fieldSelect2 = $field[shortcodeUIData.select2_handle]({
 			placeholder: "Search",
 			multiple: this.model.get( 'multiple' ),
 
@@ -1835,8 +1834,7 @@ sui.controllers.MediaController = mediaController.extend({
 	},
 
 	destroySelect2UI: function() {
-                var select2 = jQuery().select2v4 ? 'select2v4' : 'select2';
-                $fieldSelect2[select2]( 'close' );
+                $fieldSelect2[shortcodeUIData.select2_handle]( 'close' );
 	}
 
 });

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -1768,7 +1768,7 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 
 		this.preselect( $field );
 
-                var $fieldSelect2 = $field[shortcodeUIData.select2_handle]({
+                var $fieldSelect2 = $field[ shortcodeUIData.select2_handle ]({
 			placeholder: "Search",
 			multiple: this.model.get( 'multiple' ),
 
@@ -1834,7 +1834,7 @@ sui.controllers.MediaController = mediaController.extend({
 	},
 
 	destroySelect2UI: function() {
-                $fieldSelect2[shortcodeUIData.select2_handle]( 'close' );
+                $fieldSelect2[ shortcodeUIData.select2_handle ]( 'close' );
 	}
 
 });

--- a/js/src/views/select2-field.js
+++ b/js/src/views/select2-field.js
@@ -103,9 +103,7 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 
 		this.preselect( $field );
 
-		var select2 = jQuery().select2v4 ? 'select2v4' : 'select2';
-
-		var $fieldSelect2 = $field[select2]({
+		var $fieldSelect2 = $field[shortcodeUIData.select2_handle]({
 			placeholder: "Search",
 			multiple: this.model.get( 'multiple' ),
 
@@ -172,8 +170,7 @@ sui.controllers.MediaController = mediaController.extend({
 	},
 
 	destroySelect2UI: function() {
-		var select2 = jQuery().select2v4 ? 'select2v4' : 'select2';
-		$fieldSelect2[select2]( 'close' );
+		$fieldSelect2[shortcodeUIData.select2_handle]( 'close' );
 	}
 
 });

--- a/js/src/views/select2-field.js
+++ b/js/src/views/select2-field.js
@@ -103,7 +103,7 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 
 		this.preselect( $field );
 
-		var $fieldSelect2 = $field[shortcodeUIData.select2_handle]({
+		var $fieldSelect2 = $field[ shortcodeUIData.select2_handle ]({
 			placeholder: "Search",
 			multiple: this.model.get( 'multiple' ),
 
@@ -170,7 +170,7 @@ sui.controllers.MediaController = mediaController.extend({
 	},
 
 	destroySelect2UI: function() {
-		$fieldSelect2[shortcodeUIData.select2_handle]( 'close' );
+		$fieldSelect2[ shortcodeUIData.select2_handle ]( 'close' );
 	}
 
 });

--- a/js/src/views/select2-field.js
+++ b/js/src/views/select2-field.js
@@ -103,7 +103,9 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 
 		this.preselect( $field );
 
-		var $fieldSelect2 = $field.select2({
+		var select2 = jQuery().select2v4 ? 'select2v4' : 'select2';
+
+		var $fieldSelect2 = $field[select2]({
 			placeholder: "Search",
 			multiple: this.model.get( 'multiple' ),
 
@@ -134,6 +136,7 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 				},
 				cache: true
 			},
+
 			escapeMarkup: function( markup ) { return markup; },
 			minimumInputLength: 1,
 			templateResult: this.templateResult,
@@ -169,8 +172,8 @@ sui.controllers.MediaController = mediaController.extend({
 	},
 
 	destroySelect2UI: function() {
-		$fieldSelect2.select2( 'close' );
+		var select2 = jQuery().select2v4 ? 'select2v4' : 'select2';
+		$fieldSelect2[select2]( 'close' );
 	}
 
 });
-

--- a/shortcode-ui.php
+++ b/shortcode-ui.php
@@ -39,6 +39,11 @@ add_action( 'init', 'shortcode_ui_init', 5 );
  * @return null
  */
 function shortcode_ui_init() {
+
+	if(defined( 'SELECT2_NOCONFLICT' ) && SELECT2_NOCONFLICT){
+		Shortcode_UI::$select2_handle = 'select2v4';
+	}
+
 	$shortcode_ui     = Shortcode_UI::get_instance();
 	$fields           = Shortcode_UI_Fields::get_instance();
 	$attachment_field = Shortcake_Field_Attachment::get_instance();


### PR DESCRIPTION
As discussed in #683 and #670, actually many popular plugin, like Advanced Custom Fields and WooCommerce, still use the Select2 v3 library and make this plugin throw JS errors due to v3/v4 incompatibility.

With this PR the user can: 

`define('SELECT2_NOCONFLICT', true);` in `wp-config.php` 

to make this plugin load select2 4.x in `$.fn.select2v4` namespace, leaving the `$.fn.select2` on v3 for all other plugins. The plugin's JS than uses the `select2v4 ` namespace if exists, otherwise it uses the standard `select2`.

An optional improvement to this PR could be to check if known incompatible plugins  are active with `is_plugin_active()` and automatically set  `SELECT2_NOCONFLICT` to true.