### PR TITLE
Reset the currentShortcode value and the menu title on close

### DIFF
--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -1181,6 +1181,10 @@ var shortcodeViewConstructor = {
 
 			// Make sure to reset state when closed.
 			frame.once( 'close submit', function() {
+				frame.state().props.set('currentShortcode', false);
+				var menuItem = frame.menu.get().get('shortcode-ui');
+				menuItem.options.text = shortcodeUIData.strings.media_frame_title;
+				menuItem.render();
 				frame.setState( 'insert' );
 			} );
 

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -349,6 +349,10 @@ $(document).ready(function(){
 
 		// Make sure to reset state when closed.
 		frame.once( 'close submit', function() {
+			frame.state().props.set('currentShortcode', false);
+			var menuItem = frame.menu.get().get('shortcode-ui');
+			menuItem.options.text = shortcodeUIData.strings.media_frame_title;
+			menuItem.render();
 			frame.setState( 'insert' );
 		} );
 
@@ -656,6 +660,10 @@ var shortcodeViewConstructor = {
 
 			// Make sure to reset state when closed.
 			frame.once( 'close submit', function() {
+				frame.state().props.set('currentShortcode', false);
+				var menuItem = frame.menu.get().get('shortcode-ui');
+				menuItem.options.text = shortcodeUIData.strings.media_frame_title;
+				menuItem.render();
 				frame.setState( 'insert' );
 			} );
 

--- a/js/src/shortcode-ui.js
+++ b/js/src/shortcode-ui.js
@@ -49,6 +49,10 @@ $(document).ready(function(){
 
 		// Make sure to reset state when closed.
 		frame.once( 'close submit', function() {
+			frame.state().props.set('currentShortcode', false);
+			var menuItem = frame.menu.get().get('shortcode-ui');
+			menuItem.options.text = shortcodeUIData.strings.media_frame_title;
+			menuItem.render();
 			frame.setState( 'insert' );
 		} );
 

--- a/js/src/utils/shortcode-view-constructor.js
+++ b/js/src/utils/shortcode-view-constructor.js
@@ -181,6 +181,10 @@ var shortcodeViewConstructor = {
 
 			// Make sure to reset state when closed.
 			frame.once( 'close submit', function() {
+				frame.state().props.set('currentShortcode', false);
+				var menuItem = frame.menu.get().get('shortcode-ui');
+				menuItem.options.text = shortcodeUIData.strings.media_frame_title;
+				menuItem.render();
 				frame.setState( 'insert' );
 			} );
 


### PR DESCRIPTION
Merges into #689 

We're correctly setting the state of the WP media modal back to
'insert', as used by WP core, when a user closes, submits, or dismisses
the shortcode UI modal. However the currentShortcode state wasn't being
reset, and the modal title wasn't being reset, so the next time the user
opened the media modal, they'd see "{Shortcode} Options" as the menu
item title, rather than "Insert Post Element" as it should be.

This change deletes and resets these props on closing the shortcode ui
frame. It could certainly stand to be refactored, but I didn't see the
best way of doing that offhand.