### PR TITLE
Communicate warning to users when no shortcodes with UI are registered

### DIFF
--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -226,7 +226,7 @@ class Shortcode_UI {
 	 * @return bool
 	 */
 	public function has_shortcodes() {
-		return ( bool ) $this->get_shortcodes();
+		return (bool) $this->get_shortcodes();
 	}
 
 	/**

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -73,11 +73,43 @@ class Shortcode_UI {
 	 * Setup plugin actions.
 	 */
 	private function setup_actions() {
+		add_action( 'admin_notices',             array( $this, 'action_admin_notices' ) );
 		add_action( 'admin_enqueue_scripts',     array( $this, 'action_admin_enqueue_scripts' ) );
 		add_action( 'wp_enqueue_editor',         array( $this, 'action_wp_enqueue_editor' ) );
 		add_action( 'media_buttons',             array( $this, 'action_media_buttons' ) );
 		add_action( 'wp_ajax_bulk_do_shortcode', array( $this, 'handle_ajax_bulk_do_shortcode' ) );
 		add_filter( 'wp_editor_settings',        array( $this, 'filter_wp_editor_settings' ), 10, 2 );
+	}
+
+	/**
+	 * Display an admin notice on activation.
+	 *
+	 * If no shortcodes with Shortcake UI are registered, this Will display a link to the plugin's wiki for examples.
+	 * If there are already plugins with UI registered, will just display a success message.
+	 *
+	 * @return void
+	 */
+	public function action_admin_notices() {
+		if ( ! get_option( 'shortcode_ui_activation_notice' ) ) {
+			return;
+		}
+
+		$shortcodes_with_ui = $this->get_shortcodes();
+
+		if ( empty( $shortcodes_with_ui ) ) {
+			echo '<div class="notice notice-warning is-dismissable"><p>'.
+				sprintf(
+					__( 'The Shortcode UI plugin will not do anything unless UI is registered for shortcodes through a theme or plugins. For examples, see <a href="%s" target="_blank">here</a>.', 'shortcode-ui' ),
+					'https://github.com/wp-shortcake/shortcake/wiki/Shortcode-UI-Examples'
+				) .
+				'</p></div>' . "\n";
+		} else {
+			echo '<div class="notice notice-info is-dismissable"><p>'.
+				esc_html__( 'That\'s all! Try out the shortcode UI through the "Add Post element" button in the post edit screen.', 'shortcode-ui' ) .
+				'</p></div>' . "\n";
+		}
+
+		delete_option( 'shortcode_ui_activation_notice' );
 	}
 
 	/**

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -112,7 +112,7 @@ class Shortcode_UI {
 				'</p></div>' . "\n";
 		} else {
 			echo '<div class="notice notice-info is-dismissable"><p>' .
-				esc_html__( 'That\'s all! Try out the shortcode UI through the "Add Post element" button in the post edit screen.', 'shortcode-ui' ) .
+				esc_html__( 'Shortcode UI is installed. Try out the shortcode UI through the "Add Post element" button in the post edit screen.', 'shortcode-ui' ) .
 				'</p></div>' . "\n";
 		}
 

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -226,7 +226,7 @@ class Shortcode_UI {
 	 * @return bool
 	 */
 	public function has_shortcodes() {
-		return ! empty( $this->get_shortcodes() );
+		return ( bool ) $this->get_shortcodes();
 	}
 
 	/**

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -94,9 +94,7 @@ class Shortcode_UI {
 			return;
 		}
 
-		$shortcodes_with_ui = $this->get_shortcodes();
-
-		if ( empty( $shortcodes_with_ui ) ) {
+		if ( ! $this->has_shortcodes() ) {
 			echo '<div class="notice notice-warning is-dismissable"><p>'.
 				sprintf(
 					__( 'The Shortcode UI plugin will not do anything unless UI is registered for shortcodes through a theme or plugins. For examples, see <a href="%s" target="_blank">here</a>.', 'shortcode-ui' ),
@@ -211,6 +209,15 @@ class Shortcode_UI {
 		}
 
 		return $shortcodes;
+	}
+
+	/**
+	 * Whether any shortcodes with UI are registered
+	 *
+	 * @return bool
+	 */
+	public function has_shortcodes() {
+		return ! empty( $this->get_shortcodes() );
 	}
 
 	/**
@@ -337,6 +344,10 @@ class Shortcode_UI {
 	 * Output an "Add Post Element" button with the media buttons.
 	 */
 	public function action_media_buttons( $editor_id ) {
+		if ( ! $this->has_shortcodes() ) {
+			return;
+		}
+
 		printf( '<button type="button" class="button shortcake-add-post-element" data-editor="%s">' .
 			'<span class="wp-media-buttons-icon dashicons dashicons-migrate"></span> %s' .
 			'</button>',

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -95,14 +95,23 @@ class Shortcode_UI {
 		}
 
 		if ( ! $this->has_shortcodes() ) {
-			echo '<div class="notice notice-warning is-dismissable"><p>'.
+			echo '<div class="notice notice-warning is-dismissable"><p>' .
 				sprintf(
-					__( 'The Shortcode UI plugin will not do anything unless UI is registered for shortcodes through a theme or plugins. For examples, see <a href="%s" target="_blank">here</a>.', 'shortcode-ui' ),
+					wp_kses(
+						/* Translators: link to plugin wiki page with examples of shortcodes supporting Shortcake UI */
+						__( 'The Shortcode UI plugin will not do anything unless UI is registered for shortcodes through a theme or plugins. For examples, see <a href="%s" target="_blank">here</a>.', 'shortcode-ui' ),
+						array(
+							'a' => array(
+								'href' => array(),
+								'target' => array(),
+							),
+						)
+					),
 					'https://github.com/wp-shortcake/shortcake/wiki/Shortcode-UI-Examples'
 				) .
 				'</p></div>' . "\n";
 		} else {
-			echo '<div class="notice notice-info is-dismissable"><p>'.
+			echo '<div class="notice notice-info is-dismissable"><p>' .
 				esc_html__( 'That\'s all! Try out the shortcode UI through the "Add Post element" button in the post edit screen.', 'shortcode-ui' ) .
 				'</p></div>' . "\n";
 		}

--- a/shortcode-ui.php
+++ b/shortcode-ui.php
@@ -111,6 +111,17 @@ function shortcode_ui_register_for_shortcode( $shortcode_tag, $args = array() ) 
 }
 
 /**
+ * Display an admin notice on activating the plugin if no shortcodes with UI are available.
+ *
+ * @return void
+ */
+function shortcode_ui_activation_notice() {
+	update_option( 'shortcode_ui_activation_notice', true );
+}
+
+register_activation_hook( __FILE__, 'shortcode_ui_activation_notice' );
+
+/**
  * Get register UI args by shortcode tag
  *
  * @param  string $shortcode_tag


### PR DESCRIPTION
This is a first attempt at addressing some of the issues pointed out in #711.

First off, if this plugin is activated, but no shortcodes are registered with Shortcake UI, an admin notice will be shown:

![screenshot from 2017-03-29 13-27-55](https://cloud.githubusercontent.com/assets/665992/24475183/ec156126-1483-11e7-94fa-de46820a9af5.png)

> The Shortcode UI plugin will not do anything unless UI is registered for shortcodes through a theme or plugins. For examples, see here.

with a link to [the wiki page here](https://github.com/wp-shortcake/shortcake/wiki/Shortcode-UI-Examples) with plugins which provide supported shortcodes.

Secondly, if there are no supported shortcodes available, the "Add Post Element" button will not be shown, as it doesn't do anything and is a source of potential confusion.