### PR TITLE
Add i18n for strings in attachment field template

### DIFF
--- a/inc/fields/class-shortcode-ui-field-attachment.php
+++ b/inc/fields/class-shortcode-ui-field-attachment.php
@@ -135,14 +135,14 @@ class Shortcode_UI_Field_Attachment {
 				</div>
 
 				<div class="thumbnail-details-container has-attachment">
-					<strong>Thumbnail Details</strong>
+					<strong><?php esc_html_e( 'Attachment Details', 'shortcode-ui' ); ?></strong>
 					<div class="filename">{{ data.filename }}</div>
 					<div class="date-formatted">{{ data.dateFormatted }}</div>
 					<div class="size">{{ data.filesizeHumanReadable }}</div>
 					<# if ( data.type === 'image' ) { #>
 						<div class="dimensions">{{ data.width }} &times; {{ data.height }}</div>
 					<# } #>
-					<div class="edit-link"><a href="{{ data.editLink }}">Edit Attachment</a></div>
+					<div class="edit-link"><a href="{{ data.editLink }}"><?php esc_html_e( 'Edit Attachment', 'shortcode-ui' ); ?></a></div>
 				</div>
 			</div>
 		</script>


### PR DESCRIPTION
Changes the text of the subhead in this field template from "Thumbnail
Details" to "Attachment Details", which is more consistent with the
surrounding text. Also wraps this field and the "Edit Attachment" link
in gettext calls, so that they can be translated.

Fixes #716.