### PR TITLE
Fix shortcake duplication bug

### DIFF
--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -840,7 +840,7 @@ Shortcode = Backbone.Model.extend({
 
 			// Encode textareas incase HTML
 			if ( attr.get( 'encode' ) ) {
-				attr.set( 'value', encodeURIComponent( decodeURIComponent( attr.get( 'value' ).replace( "%", "&#37;" ) ) ), { silent: true } );
+				attr.set( 'value', encodeURIComponent( decodeURIComponent( attr.get( 'value' ).replace( /%/g, "&#37;" ) ) ), { silent: true } );
 			}
 
 			attrs.push( attr.get( 'attr' ) + '="' + attr.get( 'value' ) + '"' );
@@ -1160,7 +1160,7 @@ var shortcodeViewConstructor = {
 	 *
 	 * @param {string} shortcodeString String representation of the shortcode
 	 */
-	edit: function( shortcodeString ) {
+	edit: function( shortcodeString, update ) {
 
 		var currentShortcode = this.parseShortcodeString( shortcodeString );
 
@@ -1179,13 +1179,8 @@ var shortcodeViewConstructor = {
 				});
 			}
 
-			// Make sure to reset state when closed.
-			frame.once( 'close submit', function() {
-				frame.state().props.set('currentShortcode', false);
-				var menuItem = frame.menu.get().get('shortcode-ui');
-				menuItem.options.text = shortcodeUIData.strings.media_frame_title;
-				menuItem.render();
-				frame.setState( 'insert' );
+			frame.mediaController.props.set( 'insertCallback', function( shortcode ) {
+				update( shortcode.formatShortcode() );
 			} );
 
 			/* Trigger render_edit */

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -840,7 +840,7 @@ Shortcode = Backbone.Model.extend({
 
 			// Encode textareas incase HTML
 			if ( attr.get( 'encode' ) ) {
-				attr.set( 'value', encodeURIComponent( decodeURIComponent( attr.get( 'value' ).replace( /%/g, "&#37;" ) ) ), { silent: true } );
+				attr.set( 'value', encodeURIComponent( decodeURIComponent( attr.get( 'value' ).replace( "%", "&#37;" ) ) ), { silent: true } );
 			}
 
 			attrs.push( attr.get( 'attr' ) + '="' + attr.get( 'value' ) + '"' );
@@ -1160,7 +1160,7 @@ var shortcodeViewConstructor = {
 	 *
 	 * @param {string} shortcodeString String representation of the shortcode
 	 */
-	edit: function( shortcodeString, update ) {
+	edit: function( shortcodeString ) {
 
 		var currentShortcode = this.parseShortcodeString( shortcodeString );
 
@@ -1179,8 +1179,13 @@ var shortcodeViewConstructor = {
 				});
 			}
 
-			frame.mediaController.props.set( 'insertCallback', function( shortcode ) {
-				update( shortcode.formatShortcode() );
+			// Make sure to reset state when closed.
+			frame.once( 'close submit', function() {
+				frame.state().props.set('currentShortcode', false);
+				var menuItem = frame.menu.get().get('shortcode-ui');
+				menuItem.options.text = shortcodeUIData.strings.media_frame_title;
+				menuItem.render();
+				frame.setState( 'insert' );
 			} );
 
 			/* Trigger render_edit */

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -47,7 +47,8 @@ var MediaController = wp.media.controller.State.extend({
 		this.props = new Backbone.Model({
 			currentShortcode: null,
 			action: 'select',
-			search: null
+			search: null,
+			insertCallback: this.insertCallback,
 		});
 
 		this.props.on( 'change:action', this.refresh, this );
@@ -70,18 +71,34 @@ var MediaController = wp.media.controller.State.extend({
 	},
 
 	insert: function() {
-		var shortcode = this.props.get('currentShortcode');
-		if ( shortcode ) {
-			send_to_editor( shortcode.formatShortcode() );
-			this.reset();
-			this.frame.close();
+		var shortcode      = this.props.get( 'currentShortcode' );
+		var insertCallback = this.props.get( 'insertCallback' );
+
+		if ( shortcode && insertCallback ) {
+			insertCallback( shortcode );
 		}
+
+		this.reset();
+		this.resetState();
+		this.frame.close();
+	},
+
+	insertCallback: function( shortcode ) {
+		window.send_to_editor( shortcode.formatShortcode() );
 	},
 
 	reset: function() {
 		this.props.set( 'action', 'select' );
 		this.props.set( 'currentShortcode', null );
 		this.props.set( 'search', null );
+		this.props.set( 'insertCallback', this.insertCallback );
+	},
+
+	resetState: function() {
+		var menuItem = this.frame.menu.get().get('shortcode-ui');
+		menuItem.options.text = shortcodeUIData.strings.media_frame_title;
+		menuItem.render();
+		this.frame.setState( 'insert' );
 	},
 
 	setActionSelect: function() {
@@ -639,7 +656,7 @@ var shortcodeViewConstructor = {
 	 *
 	 * @param {string} shortcodeString String representation of the shortcode
 	 */
-	edit: function( shortcodeString ) {
+	edit: function( shortcodeString, update ) {
 
 		var currentShortcode = this.parseShortcodeString( shortcodeString );
 
@@ -658,13 +675,8 @@ var shortcodeViewConstructor = {
 				});
 			}
 
-			// Make sure to reset state when closed.
-			frame.once( 'close submit', function() {
-				frame.state().props.set('currentShortcode', false);
-				var menuItem = frame.menu.get().get('shortcode-ui');
-				menuItem.options.text = shortcodeUIData.strings.media_frame_title;
-				menuItem.render();
-				frame.setState( 'insert' );
+			frame.mediaController.props.set( 'insertCallback', function( shortcode ) {
+				update( shortcode.formatShortcode() );
 			} );
 
 			/* Trigger render_edit */
@@ -1821,7 +1833,7 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 
 		this.preselect( $field );
 
-                var $fieldSelect2 = $field[ shortcodeUIData.select2_handle ]({
+		var $fieldSelect2 = $field[ shortcodeUIData.select2_handle ]({
 			placeholder: "Search",
 			multiple: this.model.get( 'multiple' ),
 
@@ -1852,6 +1864,7 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 				},
 				cache: true
 			},
+
 			escapeMarkup: function( markup ) { return markup; },
 			minimumInputLength: 1,
 			templateResult: this.templateResult,
@@ -1887,11 +1900,10 @@ sui.controllers.MediaController = mediaController.extend({
 	},
 
 	destroySelect2UI: function() {
-                $fieldSelect2[ shortcodeUIData.select2_handle ]( 'close' );
+		$fieldSelect2[ shortcodeUIData.select2_handle ]( 'close' );
 	}
 
 });
-
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 },{"./../utils/sui.js":10}],24:[function(require,module,exports){

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -47,8 +47,7 @@ var MediaController = wp.media.controller.State.extend({
 		this.props = new Backbone.Model({
 			currentShortcode: null,
 			action: 'select',
-			search: null,
-			insertCallback: this.insertCallback,
+			search: null
 		});
 
 		this.props.on( 'change:action', this.refresh, this );
@@ -71,34 +70,18 @@ var MediaController = wp.media.controller.State.extend({
 	},
 
 	insert: function() {
-		var shortcode      = this.props.get( 'currentShortcode' );
-		var insertCallback = this.props.get( 'insertCallback' );
-
-		if ( shortcode && insertCallback ) {
-			insertCallback( shortcode );
+		var shortcode = this.props.get('currentShortcode');
+		if ( shortcode ) {
+			send_to_editor( shortcode.formatShortcode() );
+			this.reset();
+			this.frame.close();
 		}
-
-		this.reset();
-		this.resetState();
-		this.frame.close();
-	},
-
-	insertCallback: function( shortcode ) {
-		window.send_to_editor( shortcode.formatShortcode() );
 	},
 
 	reset: function() {
 		this.props.set( 'action', 'select' );
 		this.props.set( 'currentShortcode', null );
 		this.props.set( 'search', null );
-		this.props.set( 'insertCallback', this.insertCallback );
-	},
-
-	resetState: function() {
-		var menuItem = this.frame.menu.get().get('shortcode-ui');
-		menuItem.options.text = shortcodeUIData.strings.media_frame_title;
-		menuItem.render();
-		this.frame.setState( 'insert' );
 	},
 
 	setActionSelect: function() {
@@ -656,7 +639,7 @@ var shortcodeViewConstructor = {
 	 *
 	 * @param {string} shortcodeString String representation of the shortcode
 	 */
-	edit: function( shortcodeString, update ) {
+	edit: function( shortcodeString ) {
 
 		var currentShortcode = this.parseShortcodeString( shortcodeString );
 
@@ -675,8 +658,13 @@ var shortcodeViewConstructor = {
 				});
 			}
 
-			frame.mediaController.props.set( 'insertCallback', function( shortcode ) {
-				update( shortcode.formatShortcode() );
+			// Make sure to reset state when closed.
+			frame.once( 'close submit', function() {
+				frame.state().props.set('currentShortcode', false);
+				var menuItem = frame.menu.get().get('shortcode-ui');
+				menuItem.options.text = shortcodeUIData.strings.media_frame_title;
+				menuItem.render();
+				frame.setState( 'insert' );
 			} );
 
 			/* Trigger render_edit */
@@ -1833,7 +1821,7 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 
 		this.preselect( $field );
 
-		var $fieldSelect2 = $field[ shortcodeUIData.select2_handle ]({
+                var $fieldSelect2 = $field[ shortcodeUIData.select2_handle ]({
 			placeholder: "Search",
 			multiple: this.model.get( 'multiple' ),
 
@@ -1864,7 +1852,6 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 				},
 				cache: true
 			},
-
 			escapeMarkup: function( markup ) { return markup; },
 			minimumInputLength: 1,
 			templateResult: this.templateResult,
@@ -1900,10 +1887,11 @@ sui.controllers.MediaController = mediaController.extend({
 	},
 
 	destroySelect2UI: function() {
-		$fieldSelect2[ shortcodeUIData.select2_handle ]( 'close' );
+                $fieldSelect2[ shortcodeUIData.select2_handle ]( 'close' );
 	}
 
 });
+
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 },{"./../utils/sui.js":10}],24:[function(require,module,exports){

--- a/js/src/controllers/media-controller.js
+++ b/js/src/controllers/media-controller.js
@@ -10,7 +10,8 @@ var MediaController = wp.media.controller.State.extend({
 		this.props = new Backbone.Model({
 			currentShortcode: null,
 			action: 'select',
-			search: null
+			search: null,
+			insertCallback: this.insertCallback,
 		});
 
 		this.props.on( 'change:action', this.refresh, this );
@@ -33,18 +34,34 @@ var MediaController = wp.media.controller.State.extend({
 	},
 
 	insert: function() {
-		var shortcode = this.props.get('currentShortcode');
-		if ( shortcode ) {
-			send_to_editor( shortcode.formatShortcode() );
-			this.reset();
-			this.frame.close();
+		var shortcode      = this.props.get( 'currentShortcode' );
+		var insertCallback = this.props.get( 'insertCallback' );
+
+		if ( shortcode && insertCallback ) {
+			insertCallback( shortcode );
 		}
+
+		this.reset();
+		this.resetState();
+		this.frame.close();
+	},
+
+	insertCallback: function( shortcode ) {
+		window.send_to_editor( shortcode.formatShortcode() );
 	},
 
 	reset: function() {
 		this.props.set( 'action', 'select' );
 		this.props.set( 'currentShortcode', null );
 		this.props.set( 'search', null );
+		this.props.set( 'insertCallback', this.insertCallback );
+	},
+
+	resetState: function() {
+		var menuItem = this.frame.menu.get().get('shortcode-ui');
+		menuItem.options.text = shortcodeUIData.strings.media_frame_title;
+		menuItem.render();
+		this.frame.setState( 'insert' );
 	},
 
 	setActionSelect: function() {

--- a/js/src/controllers/media-controller.js
+++ b/js/src/controllers/media-controller.js
@@ -10,8 +10,7 @@ var MediaController = wp.media.controller.State.extend({
 		this.props = new Backbone.Model({
 			currentShortcode: null,
 			action: 'select',
-			search: null,
-			insertCallback: this.insertCallback,
+			search: null
 		});
 
 		this.props.on( 'change:action', this.refresh, this );
@@ -34,34 +33,18 @@ var MediaController = wp.media.controller.State.extend({
 	},
 
 	insert: function() {
-		var shortcode      = this.props.get( 'currentShortcode' );
-		var insertCallback = this.props.get( 'insertCallback' );
-
-		if ( shortcode && insertCallback ) {
-			insertCallback( shortcode );
+		var shortcode = this.props.get('currentShortcode');
+		if ( shortcode ) {
+			send_to_editor( shortcode.formatShortcode() );
+			this.reset();
+			this.frame.close();
 		}
-
-		this.reset();
-		this.resetState();
-		this.frame.close();
-	},
-
-	insertCallback: function( shortcode ) {
-		window.send_to_editor( shortcode.formatShortcode() );
 	},
 
 	reset: function() {
 		this.props.set( 'action', 'select' );
 		this.props.set( 'currentShortcode', null );
 		this.props.set( 'search', null );
-		this.props.set( 'insertCallback', this.insertCallback );
-	},
-
-	resetState: function() {
-		var menuItem = this.frame.menu.get().get('shortcode-ui');
-		menuItem.options.text = shortcodeUIData.strings.media_frame_title;
-		menuItem.render();
-		this.frame.setState( 'insert' );
 	},
 
 	setActionSelect: function() {

--- a/js/src/utils/shortcode-view-constructor.js
+++ b/js/src/utils/shortcode-view-constructor.js
@@ -160,7 +160,7 @@ var shortcodeViewConstructor = {
 	 *
 	 * @param {string} shortcodeString String representation of the shortcode
 	 */
-	edit: function( shortcodeString ) {
+	edit: function( shortcodeString, update ) {
 
 		var currentShortcode = this.parseShortcodeString( shortcodeString );
 
@@ -179,13 +179,8 @@ var shortcodeViewConstructor = {
 				});
 			}
 
-			// Make sure to reset state when closed.
-			frame.once( 'close submit', function() {
-				frame.state().props.set('currentShortcode', false);
-				var menuItem = frame.menu.get().get('shortcode-ui');
-				menuItem.options.text = shortcodeUIData.strings.media_frame_title;
-				menuItem.render();
-				frame.setState( 'insert' );
+			frame.mediaController.props.set( 'insertCallback', function( shortcode ) {
+				update( shortcode.formatShortcode() );
 			} );
 
 			/* Trigger render_edit */

--- a/js/src/utils/shortcode-view-constructor.js
+++ b/js/src/utils/shortcode-view-constructor.js
@@ -160,7 +160,7 @@ var shortcodeViewConstructor = {
 	 *
 	 * @param {string} shortcodeString String representation of the shortcode
 	 */
-	edit: function( shortcodeString, update ) {
+	edit: function( shortcodeString ) {
 
 		var currentShortcode = this.parseShortcodeString( shortcodeString );
 
@@ -179,8 +179,13 @@ var shortcodeViewConstructor = {
 				});
 			}
 
-			frame.mediaController.props.set( 'insertCallback', function( shortcode ) {
-				update( shortcode.formatShortcode() );
+			// Make sure to reset state when closed.
+			frame.once( 'close submit', function() {
+				frame.state().props.set('currentShortcode', false);
+				var menuItem = frame.menu.get().get('shortcode-ui');
+				menuItem.options.text = shortcodeUIData.strings.media_frame_title;
+				menuItem.render();
+				frame.setState( 'insert' );
 			} );
 
 			/* Trigger render_edit */


### PR DESCRIPTION
The bug: since 4.7.4, updating an existing shortcake inserts a duplicate instead of actually updating.

Closes #723 

I figured I'd take a look at the code for core MCE views (galleries etc), to try and work what they do differently and why it is only an issue for shortcake. I noticed that there is an `update` callback passed to the `edit` method of MCE views. But we aren't using this and just use `send_to_editor`. 

To be honest, I'm somewhat surprised this was ever smart enough to know when to update, and when to insert.

This pull request updates the shortcode state controller to allow for a custom insert callback, and defaults to `send_to_editor` if not provided.

