### PR TITLE
Update plugin version

### DIFF
--- a/shortcode-ui.php
+++ b/shortcode-ui.php
@@ -19,7 +19,7 @@
  * GNU General Public License for more details.
  */
 
-define( 'SHORTCODE_UI_VERSION', '0.7.1' );
+define( 'SHORTCODE_UI_VERSION', '0.7.2' );
 
 require_once dirname( __FILE__ ) . '/inc/class-shortcode-ui.php';
 require_once dirname( __FILE__ ) . '/inc/fields/class-shortcode-ui-fields.php';


### PR DESCRIPTION
The SHORTCODE_UI_VERSION should also be updated accordingly, to cache bust the affected javascript file(s) in the latest version (0.7.2).