### PR TITLE
Make sure `render_edit` hook fires after media frame is created

### DIFF
--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -145,8 +145,7 @@ var MediaController = wp.media.controller.State.extend({
 			 *           Reference to the shortcode model used in this overlay.
 			 */
 			var hookName = 'shortcode-ui.render_edit';
-			var shortcodeModel = this.shortcodeModel;
-			wp.shortcake.hooks.doAction( hookName, shortcodeModel );
+			wp.shortcake.hooks.doAction( hookName, currentShortcode );
 
 		}.bind( this ) );
 

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -136,8 +136,17 @@ var MediaController = wp.media.controller.State.extend({
 				this.frame.mediaController.toggleSidebar( false );
 			}.bind( this ) );
 
-			var hookName = 'shortcode-ui.after_set_action_update';
-			wp.shortcake.hooks.doAction( hookName, currentShortcode );
+			/*
+			 * Action run after an edit shortcode overlay is rendered.
+			 *
+			 * Called as `shortcode-ui.render_edit`.
+			 *
+			 * @param shortcodeModel (object)
+			 *           Reference to the shortcode model used in this overlay.
+			 */
+			var hookName = 'shortcode-ui.render_edit';
+			var shortcodeModel = this.shortcodeModel;
+			wp.shortcake.hooks.doAction( hookName, shortcodeModel );
 
 		}.bind( this ) );
 
@@ -681,19 +690,6 @@ var shortcodeViewConstructor = {
 			frame.mediaController.props.set( 'insertCallback', function( shortcode ) {
 				update( shortcode.formatShortcode() );
 			} );
-
-			/* Trigger render_edit */
-			/*
-			 * Action run after an edit shortcode overlay is rendered.
-			 *
-			 * Called as `shortcode-ui.render_edit`.
-			 *
-			 * @param shortcodeModel (object)
-			 *           Reference to the shortcode model used in this overlay.
-			 */
-			var hookName = 'shortcode-ui.render_edit';
-			var shortcodeModel = this.shortcodeModel;
-			wp.shortcake.hooks.doAction( hookName, shortcodeModel );
 
 		}
 

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -136,6 +136,9 @@ var MediaController = wp.media.controller.State.extend({
 				this.frame.mediaController.toggleSidebar( false );
 			}.bind( this ) );
 
+			var hookName = 'shortcode-ui.after_set_action_update';
+			wp.shortcake.hooks.doAction( hookName, currentShortcode );
+
 		}.bind( this ) );
 
 	},

--- a/js/src/controllers/media-controller.js
+++ b/js/src/controllers/media-controller.js
@@ -99,8 +99,17 @@ var MediaController = wp.media.controller.State.extend({
 				this.frame.mediaController.toggleSidebar( false );
 			}.bind( this ) );
 
-			var hookName = 'shortcode-ui.after_set_action_update';
-			wp.shortcake.hooks.doAction( hookName, currentShortcode );
+			/*
+			 * Action run after an edit shortcode overlay is rendered.
+			 *
+			 * Called as `shortcode-ui.render_edit`.
+			 *
+			 * @param shortcodeModel (object)
+			 *           Reference to the shortcode model used in this overlay.
+			 */
+			var hookName = 'shortcode-ui.render_edit';
+			var shortcodeModel = this.shortcodeModel;
+			wp.shortcake.hooks.doAction( hookName, shortcodeModel );
 
 		}.bind( this ) );
 

--- a/js/src/controllers/media-controller.js
+++ b/js/src/controllers/media-controller.js
@@ -108,8 +108,7 @@ var MediaController = wp.media.controller.State.extend({
 			 *           Reference to the shortcode model used in this overlay.
 			 */
 			var hookName = 'shortcode-ui.render_edit';
-			var shortcodeModel = this.shortcodeModel;
-			wp.shortcake.hooks.doAction( hookName, shortcodeModel );
+			wp.shortcake.hooks.doAction( hookName, currentShortcode );
 
 		}.bind( this ) );
 

--- a/js/src/controllers/media-controller.js
+++ b/js/src/controllers/media-controller.js
@@ -99,6 +99,9 @@ var MediaController = wp.media.controller.State.extend({
 				this.frame.mediaController.toggleSidebar( false );
 			}.bind( this ) );
 
+			var hookName = 'shortcode-ui.after_set_action_update';
+			wp.shortcake.hooks.doAction( hookName, currentShortcode );
+
 		}.bind( this ) );
 
 	},

--- a/js/src/utils/shortcode-view-constructor.js
+++ b/js/src/utils/shortcode-view-constructor.js
@@ -183,19 +183,6 @@ var shortcodeViewConstructor = {
 				update( shortcode.formatShortcode() );
 			} );
 
-			/* Trigger render_edit */
-			/*
-			 * Action run after an edit shortcode overlay is rendered.
-			 *
-			 * Called as `shortcode-ui.render_edit`.
-			 *
-			 * @param shortcodeModel (object)
-			 *           Reference to the shortcode model used in this overlay.
-			 */
-			var hookName = 'shortcode-ui.render_edit';
-			var shortcodeModel = this.shortcodeModel;
-			wp.shortcake.hooks.doAction( hookName, shortcodeModel );
-
 		}
 
 	},


### PR DESCRIPTION
Following on from [this ticket](https://github.com/wp-shortcake/shortcake/pull/689#issuecomment-284098837), I have been talking to @rahulsprajapati about how best to achive what he wanted.

Using `setTimeout` as you suggested works fine, however I think I agree with him that there could be a better solution that guarantees that his code is run at the correct time. Having another action `shortcode-ui.after_set_action_update` would be useful.

We currently have an action`shortcode-ui.render_edit`, but shortcake renders the modal content inside a `defer` callback. Because of this I think it makes sense to add an extra action.  