### PR TITLE
Render thumbnails for non-image attachments

### DIFF
--- a/inc/fields/class-shortcode-ui-field-attachment.php
+++ b/inc/fields/class-shortcode-ui-field-attachment.php
@@ -106,7 +106,7 @@ class Shortcode_UI_Field_Attachment {
 
 					<button class="button button-small remove" data-id="{{ data.id }}">×</button>
 
-					<# if ( data.type === 'image' && data.sizes && data.sizes.thumbnail ) { #>
+					<# if ( data.sizes && data.sizes.thumbnail ) { #>
 						<div class="thumbnail">
 							<div class="centered">
 								<img src="{{ data.sizes.thumbnail.url }}" alt="" width="{{ data.sizes.thumbnail.width }}" height="{{ data.sizes.thumbnail.height }}" />


### PR DESCRIPTION
This is similar to how the wordpress media browser renders attachments; if a non-image attachment has specified a thumbnail meta item use it as the thumbnail.

https://github.com/WordPress/WordPress/blob/31d4d81039226aa8d3f5229af874ee5b9e2a9482/wp-includes/media-template.php#L462