### PR TITLE
Ensure select's data value is an array before filtering

### DIFF
--- a/inc/templates/edit-form.tpl.php
+++ b/inc/templates/edit-form.tpl.php
@@ -54,11 +54,11 @@
 				<# if ( 'options' in option && 'label' in option ) { #>
 					<optgroup label="{{ option.label }}">
 						<# _.each( option.options, function( optgroupOption ) { #>
-							<option value="{{ optgroupOption.value }}" <# if ( ! _.isEmpty( _.filter( data.value, function(val) { return val === optgroupOption.value; } ) ) ) { print('selected'); } #>>{{ optgroupOption.label }}</option>
+							<option value="{{ optgroupOption.value }}" <# if ( ! _.isEmpty( _.filter( _.isArray( data.value ) ? data.value : data.value.split(), function(val) { return val === optgroupOption.value; } ) ) ) { print('selected'); } #>>{{ optgroupOption.label }}</option>
 						<# }); #>
 					</optgroup>
 				<# } else { #>
-					<option value="{{ option.value }}" <# if ( ! _.isEmpty( _.filter( data.value, function(val) { return val === option.value; } ) ) ) { print('selected'); } #>>{{ option.label }}</option>
+					<option value="{{ option.value }}" <# if ( ! _.isEmpty( _.filter( _.isArray( data.value ) ? data.value : data.value.split(), function(val) { return val === option.value; } ) ) ) { print('selected'); } #>>{{ option.label }}</option>
 				<# } #>
 
 			<# }); #>


### PR DESCRIPTION
During work in #707 to improve support for multi-select fields, handling of comma separated strings was removed as it may have been confusing if an option value had commas in it.

See 9894162ab8bf02941e9611766d5cc3d63d337e96

After this change, string values for single select elements are filtered as if they were arrays. This causes only the first character of a string to be compared to the select value. This in turn results in all select fields set to first option because nothing is seen as selected.

We can accept arrays, but also `split()` with no separator to turn strings into an array so that everything is parsed the same.