### PR TITLE
Add a nonce to the bulk shortcode ajax handler

### DIFF
--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -462,6 +462,7 @@ class Shortcode_UI {
 	 * Get a bunch of shortcodes to render in MCE preview.
 	 */
 	public function handle_ajax_bulk_do_shortcode() {
+		check_ajax_referer( 'shortcode-ui-preview', 'nonce' );
 
 		if ( is_array( $_POST['queries'] ) ) {
 

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -968,7 +968,8 @@ var Fetcher = (function() {
 		}
 
 		var request = wp.ajax.post( 'bulk_do_shortcode', {
-			queries: _.pluck( fetcher.queries, 'query' )
+			queries: _.pluck( fetcher.queries, 'query' ),
+			nonce: shortcodeUIData.nonces.preview
 		});
 
 		request.done( function( responseData ) {

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -475,7 +475,8 @@ var Fetcher = (function() {
 		}
 
 		var request = wp.ajax.post( 'bulk_do_shortcode', {
-			queries: _.pluck( fetcher.queries, 'query' )
+			queries: _.pluck( fetcher.queries, 'query' ),
+			nonce: shortcodeUIData.nonces.preview
 		});
 
 		request.done( function( responseData ) {

--- a/js/src/utils/fetcher.js
+++ b/js/src/utils/fetcher.js
@@ -82,7 +82,8 @@ var Fetcher = (function() {
 		}
 
 		var request = wp.ajax.post( 'bulk_do_shortcode', {
-			queries: _.pluck( fetcher.queries, 'query' )
+			queries: _.pluck( fetcher.queries, 'query' ),
+			nonce: shortcodeUIData.nonces.preview
 		});
 
 		request.done( function( responseData ) {


### PR DESCRIPTION
A 10up-Third-Party PHPCS run pointed out that `Shortcode_UI::handle_ajax_bulk_do_shortcode()` was processing user data without a nonce check. This adds the preview nonce already in the code to the request and checks it before processing data.

I also noticed that each shortcode also sends a nonce to the ajax handler along with its data, although that nonce is never checked. I'm not really familiar with what side effects we'd see by either removing the nonce or checking it on a shortcode-by-shortcode basis. Let me know if I should go ahead and remove those extra nonce fields or rework where the nonces are checked.