### PR TITLE
Allow to filter query_args in post_select ajax call

### DIFF
--- a/inc/fields/class-shortcode-ui-field-post-select.php
+++ b/inc/fields/class-shortcode-ui-field-post-select.php
@@ -85,6 +85,7 @@ class Shortcode_UI_Field_Post_Select {
 		$nonce               = isset( $_GET['nonce'] ) ? sanitize_text_field( $_GET['nonce'] ) : null;
 		$requested_shortcode = isset( $_GET['shortcode'] ) ? sanitize_text_field( $_GET['shortcode'] ) : null;
 		$requested_attr      = isset( $_GET['attr'] ) ? sanitize_text_field( $_GET['attr'] ) : null;
+		$postid              = isset( $_GET['postid'] ) ? absint( $_GET['postid'] ) : 0;
 
 		$response            = array(
 			'items'          => array(),
@@ -134,6 +135,8 @@ class Shortcode_UI_Field_Post_Select {
 			$query_args['orderby']  = 'post__in';
 			$query_args['ignore_sticky_posts'] = true;
 		}
+
+		$query_args = apply_filters( 'shortcode_ui_post_field_query_args', $query_args, $postid );
 
 		$query = new WP_Query( $query_args );
 

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -1072,8 +1072,7 @@ sui.views.editAttributeFieldPostSelect = sui.views.editAttributeSelect2Field.ext
 
 	ajaxData: {
 		action    : 'shortcode_ui_post_field',
-		nonce     : shortcodeUiPostFieldData.nonce,
-		postid    : $( '#post_ID' ).val(),
+		nonce     : shortcodeUiPostFieldData.nonce
 	},
 
 	events: {
@@ -1775,7 +1774,8 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 			var request = {
 				include   : _preselected,
 				shortcode : this.shortcode.get( 'shortcode_tag'),
-				attr      : this.model.get( 'attr' )
+				attr      : this.model.get( 'attr' ),
+				postid    : $( '#post_ID' ).val()
 			};
 
 			$.get( ajaxurl, $.extend( request, this.ajaxData ),

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -1073,6 +1073,7 @@ sui.views.editAttributeFieldPostSelect = sui.views.editAttributeSelect2Field.ext
 	ajaxData: {
 		action    : 'shortcode_ui_post_field',
 		nonce     : shortcodeUiPostFieldData.nonce,
+		postid    : $( '#post_ID' ).val(),
 	},
 
 	events: {

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -1774,8 +1774,7 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 			var request = {
 				include   : _preselected,
 				shortcode : this.shortcode.get( 'shortcode_tag'),
-				attr      : this.model.get( 'attr' ),
-				postid    : $( '#post_ID' ).val()
+				attr      : this.model.get( 'attr' )
 			};
 
 			$.get( ajaxurl, $.extend( request, this.ajaxData ),
@@ -1848,7 +1847,8 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 						s         : params.term, // search term
 						page      : params.page,
 						shortcode : self.shortcode.get( 'shortcode_tag'),
-						attr      : self.model.get( 'attr' )
+						attr      : self.model.get( 'attr' ),
+						postid    : $( '#post_ID' ).val()
 					}, self.ajaxData );
 				},
 				processResults: function (response, params) {

--- a/js/src/views/edit-attribute-field-post-select.js
+++ b/js/src/views/edit-attribute-field-post-select.js
@@ -9,8 +9,7 @@ sui.views.editAttributeFieldPostSelect = sui.views.editAttributeSelect2Field.ext
 
 	ajaxData: {
 		action    : 'shortcode_ui_post_field',
-		nonce     : shortcodeUiPostFieldData.nonce,
-		postid    : $( '#post_ID' ).val(),
+		nonce     : shortcodeUiPostFieldData.nonce
 	},
 
 	events: {

--- a/js/src/views/edit-attribute-field-post-select.js
+++ b/js/src/views/edit-attribute-field-post-select.js
@@ -10,6 +10,7 @@ sui.views.editAttributeFieldPostSelect = sui.views.editAttributeSelect2Field.ext
 	ajaxData: {
 		action    : 'shortcode_ui_post_field',
 		nonce     : shortcodeUiPostFieldData.nonce,
+		postid    : $( '#post_ID' ).val(),
 	},
 
 	events: {

--- a/js/src/views/select2-field.js
+++ b/js/src/views/select2-field.js
@@ -43,7 +43,8 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 			var request = {
 				include   : _preselected,
 				shortcode : this.shortcode.get( 'shortcode_tag'),
-				attr      : this.model.get( 'attr' )
+				attr      : this.model.get( 'attr' ),
+				postid    : $( '#post_ID' ).val()
 			};
 
 			$.get( ajaxurl, $.extend( request, this.ajaxData ),

--- a/js/src/views/select2-field.js
+++ b/js/src/views/select2-field.js
@@ -43,8 +43,7 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 			var request = {
 				include   : _preselected,
 				shortcode : this.shortcode.get( 'shortcode_tag'),
-				attr      : this.model.get( 'attr' ),
-				postid    : $( '#post_ID' ).val()
+				attr      : this.model.get( 'attr' )
 			};
 
 			$.get( ajaxurl, $.extend( request, this.ajaxData ),
@@ -117,7 +116,8 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 						s         : params.term, // search term
 						page      : params.page,
 						shortcode : self.shortcode.get( 'shortcode_tag'),
-						attr      : self.model.get( 'attr' )
+						attr      : self.model.get( 'attr' ),
+						postid    : $( '#post_ID' ).val()
 					}, self.ajaxData );
 				},
 				processResults: function (response, params) {


### PR DESCRIPTION
I add post id to the post_select ajax call, then a allow to alter the query args for more extendability.

This will solve my issue that return the post list based on which post type it's currently editing.
and it also can fix this issue #625 