### PR TITLE
Don't override global select2 z-indexing

### DIFF
--- a/css/sass/_select2-fields.scss
+++ b/css/sass/_select2-fields.scss
@@ -40,7 +40,7 @@
 
 }
 
-.select2-container {
+.select2-container--shortcake {
 	z-index: 160000; // Make sure Select2 UI is visible above media modal
 	max-width: 300px;
 }

--- a/css/shortcode-ui.css
+++ b/css/shortcode-ui.css
@@ -239,7 +239,7 @@
   border-color: #5b9dd9;
   box-shadow: 0 0 2px rgba(30, 140, 190, 0.8); }
 
-.select2-container {
+.select2-container--shortcake {
   z-index: 160000;
   max-width: 300px; }
 

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -1837,6 +1837,7 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 		var $fieldSelect2 = $field[ shortcodeUIData.select2_handle ]({
 			placeholder: "Search",
 			multiple: this.model.get( 'multiple' ),
+			theme: $.fn.select2.defaults.defaults.theme + ' select2-container--shortcake',
 
 			ajax: {
 				url: ajaxurl,

--- a/js/src/views/select2-field.js
+++ b/js/src/views/select2-field.js
@@ -106,6 +106,7 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 		var $fieldSelect2 = $field[ shortcodeUIData.select2_handle ]({
 			placeholder: "Search",
 			multiple: this.model.get( 'multiple' ),
+			theme: $.fn.select2.defaults.defaults.theme + ' select2-container--shortcake',
 
 			ajax: {
 				url: ajaxurl,


### PR DESCRIPTION
Because the select2 fields we're using here need to show up just over the absolutely positioned media modal, we're setting a z-index value of 16001, just above that modal.

However, there are other places in the WP admin (like the customizer) which require a much higher z-index value, so it would be better to target only the select2 instance which we're using.

This commit uses the "theme" argument to assign an additional classname to the select2 container, and then targets the container in CSS using the new classname.

Fixes #748