### PR TITLE
Add missing call of triggerCallbacks on attachmets in render

### DIFF
--- a/js/src/views/edit-attribute-field-attachment.js
+++ b/js/src/views/edit-attribute-field-attachment.js
@@ -102,6 +102,8 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 
 		this._renderAll();
 
+        this.triggerCallbacks();
+
 	},
 
 	_renderAll: function() {


### PR DESCRIPTION
Wondering why my hooks didn't work like expacted on attachmet-fields. I recognised this missing Line compared to all other render-functions (edit-attribute-filed & edit-attribute-field-color) calling ``triggerCallbacks()`` in ``render()``. 

I guess it got lost in 14e424df22a091b4483b4b387495bee34ae71bb0.