### PR TITLE
Fix field type for term_select field in example shortcode

### DIFF
--- a/dev.php
+++ b/dev.php
@@ -199,7 +199,7 @@ function shortcode_ui_dev_advanced_example() {
 		array(
 			'label'    => __( 'Select Tag', 'shortcode-ui-example', 'shortcode-ui' ),
 			'attr'     => 'tag',
-			'type'     => 'tag_select',
+			'type'     => 'term_select',
 			'taxonomy' => 'post_tag',
 			'multiple' => true,
 		),


### PR DESCRIPTION
We added a term select field to the example plugin, but because the type
was set wrong, it isn't actually rendering. This just fixes the field
type, so that it's correct in our documentation.

See #759