### PR TITLE
Avoid saving "null" values on empty select2 fields

### DIFF
--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -833,8 +833,9 @@ Shortcode = Backbone.Model.extend({
 
 		this.get( 'attrs' ).each( function( attr ) {
 
+			console.log( attr.get('attr'), attr.get('value') );
 			// Skip empty attributes.
-			if ( ! attr.get( 'value' ) ||  attr.get( 'value' ).length < 1 ) {
+			if ( ! attr.get( 'value' ) || attr.get( 'value' ).length < 1 ) {
 				return;
 			}
 

--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -833,7 +833,6 @@ Shortcode = Backbone.Model.extend({
 
 		this.get( 'attrs' ).each( function( attr ) {
 
-			console.log( attr.get('attr'), attr.get('value') );
 			// Skip empty attributes.
 			if ( ! attr.get( 'value' ) || attr.get( 'value' ).length < 1 ) {
 				return;

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -279,8 +279,9 @@ Shortcode = Backbone.Model.extend({
 
 		this.get( 'attrs' ).each( function( attr ) {
 
+			console.log( attr.get('attr'), attr.get('value') );
 			// Skip empty attributes.
-			if ( ! attr.get( 'value' ) ||  attr.get( 'value' ).length < 1 ) {
+			if ( ! attr.get( 'value' ) || attr.get( 'value' ).length < 1 ) {
 				return;
 			}
 
@@ -889,6 +890,8 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 		}.bind( this ) );
 
 		this._renderAll();
+
+        this.triggerCallbacks();
 
 	},
 
@@ -1751,10 +1754,16 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 	inputChanged: function(e) {
 		var _selected = $( e.currentTarget ).val();
 
+		// Empty fields will have null values. We don't want to coerce that to the string "null".
+		if ( _selected == null ) {
+			_selected = '';
+		}
+
 		// Store multiple selections as comma-delimited list
 		if ( Array.isArray( _selected ) ) {
 			_selected = _selected.join( ',' );
 		}
+
 
 		this.setValue( String( _selected ) );
 		this.triggerCallbacks();

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -279,7 +279,6 @@ Shortcode = Backbone.Model.extend({
 
 		this.get( 'attrs' ).each( function( attr ) {
 
-			console.log( attr.get('attr'), attr.get('value') );
 			// Skip empty attributes.
 			if ( ! attr.get( 'value' ) || attr.get( 'value' ).length < 1 ) {
 				return;
@@ -1755,7 +1754,7 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 		var _selected = $( e.currentTarget ).val();
 
 		// Empty fields will have null values. We don't want to coerce that to the string "null".
-		if ( _selected == null ) {
+		if ( _selected === null ) {
 			_selected = '';
 		}
 
@@ -1763,7 +1762,6 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 		if ( Array.isArray( _selected ) ) {
 			_selected = _selected.join( ',' );
 		}
-
 
 		this.setValue( String( _selected ) );
 		this.triggerCallbacks();

--- a/js/src/models/shortcode.js
+++ b/js/src/models/shortcode.js
@@ -68,7 +68,6 @@ Shortcode = Backbone.Model.extend({
 
 		this.get( 'attrs' ).each( function( attr ) {
 
-			console.log( attr.get('attr'), attr.get('value') );
 			// Skip empty attributes.
 			if ( ! attr.get( 'value' ) || attr.get( 'value' ).length < 1 ) {
 				return;

--- a/js/src/models/shortcode.js
+++ b/js/src/models/shortcode.js
@@ -68,8 +68,9 @@ Shortcode = Backbone.Model.extend({
 
 		this.get( 'attrs' ).each( function( attr ) {
 
+			console.log( attr.get('attr'), attr.get('value') );
 			// Skip empty attributes.
-			if ( ! attr.get( 'value' ) ||  attr.get( 'value' ).length < 1 ) {
+			if ( ! attr.get( 'value' ) || attr.get( 'value' ).length < 1 ) {
 				return;
 			}
 

--- a/js/src/views/select2-field.js
+++ b/js/src/views/select2-field.js
@@ -20,10 +20,16 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 	inputChanged: function(e) {
 		var _selected = $( e.currentTarget ).val();
 
+		// Empty fields will have null values. We don't want to coerce that to the string "null".
+		if ( _selected == null ) {
+			_selected = '';
+		}
+
 		// Store multiple selections as comma-delimited list
 		if ( Array.isArray( _selected ) ) {
 			_selected = _selected.join( ',' );
 		}
+
 
 		this.setValue( String( _selected ) );
 		this.triggerCallbacks();

--- a/js/src/views/select2-field.js
+++ b/js/src/views/select2-field.js
@@ -21,7 +21,7 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 		var _selected = $( e.currentTarget ).val();
 
 		// Empty fields will have null values. We don't want to coerce that to the string "null".
-		if ( _selected == null ) {
+		if ( _selected === null ) {
 			_selected = '';
 		}
 
@@ -29,7 +29,6 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 		if ( Array.isArray( _selected ) ) {
 			_selected = _selected.join( ',' );
 		}
-
 
 		this.setValue( String( _selected ) );
 		this.triggerCallbacks();


### PR DESCRIPTION
We're coercing the value of select2 fields to a string, in order to
handle some edge cases in post and term select fields with multiple=true.

However, after deleting all values from a multiple select field which
had been previously updated with one or more values, that attribute's
value is `null`.

We don't want to coerce this empty value to the string "null".
This PR fixes the issue by replacing null attribute values with the
empty string, which doesn't get saved when the model is run through
`Shortcode.formatShortcode()`.

Fixes #758.