### PR TITLE
Remove unused method for fetching preview of single shortcode

### DIFF
--- a/js-tests/build/specs.js
+++ b/js-tests/build/specs.js
@@ -1118,41 +1118,8 @@ var shortcodeViewConstructor = {
 	delayedFetch: function() {
 		return fetcher.queueToFetch({
 			post_id: $( '#post_ID' ).val(),
-			shortcode: this.shortcodeModel.formatShortcode(),
-			nonce: shortcodeUIData.nonces.preview,
+			shortcode: this.shortcodeModel.formatShortcode()
 		});
-	},
-
-	/**
-	 * Fetch a preview of a single shortcode.
-	 *
-	 * Async. Sets this.content and calls this.render.
-	 *
-	 * @return undefined
-	 */
-	fetch: function() {
-		var self = this;
-
-		if ( ! this.fetching ) {
-			this.fetching = true;
-
-			wp.ajax.post( 'do_shortcode', {
-				post_id: $( '#post_ID' ).val(),
-				shortcode: this.shortcodeModel.formatShortcode(),
-				nonce: shortcodeUIData.nonces.preview,
-			}).done( function( response ) {
-				if ( '' === response ) {
-					self.content = '<span class="shortcake-notice shortcake-empty">' + self.shortcodeModel.formatShortcode() + '</span>';
-				} else {
-					self.content = response;
-				}
-			}).fail( function() {
-				self.content = '<span class="shortcake-error">' + shortcodeUIData.strings.mce_view_error + '</span>';
-			} ).always( function() {
-				delete self.fetching;
-				self.render( null, true );
-			} );
-		}
 	},
 
 	/**

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -625,41 +625,8 @@ var shortcodeViewConstructor = {
 	delayedFetch: function() {
 		return fetcher.queueToFetch({
 			post_id: $( '#post_ID' ).val(),
-			shortcode: this.shortcodeModel.formatShortcode(),
-			nonce: shortcodeUIData.nonces.preview,
+			shortcode: this.shortcodeModel.formatShortcode()
 		});
-	},
-
-	/**
-	 * Fetch a preview of a single shortcode.
-	 *
-	 * Async. Sets this.content and calls this.render.
-	 *
-	 * @return undefined
-	 */
-	fetch: function() {
-		var self = this;
-
-		if ( ! this.fetching ) {
-			this.fetching = true;
-
-			wp.ajax.post( 'do_shortcode', {
-				post_id: $( '#post_ID' ).val(),
-				shortcode: this.shortcodeModel.formatShortcode(),
-				nonce: shortcodeUIData.nonces.preview,
-			}).done( function( response ) {
-				if ( '' === response ) {
-					self.content = '<span class="shortcake-notice shortcake-empty">' + self.shortcodeModel.formatShortcode() + '</span>';
-				} else {
-					self.content = response;
-				}
-			}).fail( function() {
-				self.content = '<span class="shortcake-error">' + shortcodeUIData.strings.mce_view_error + '</span>';
-			} ).always( function() {
-				delete self.fetching;
-				self.render( null, true );
-			} );
-		}
 	},
 
 	/**
@@ -889,6 +856,8 @@ var editAttributeFieldAttachment = sui.views.editAttributeField.extend( {
 		}.bind( this ) );
 
 		this._renderAll();
+
+        this.triggerCallbacks();
 
 	},
 

--- a/js/src/utils/shortcode-view-constructor.js
+++ b/js/src/utils/shortcode-view-constructor.js
@@ -118,41 +118,8 @@ var shortcodeViewConstructor = {
 	delayedFetch: function() {
 		return fetcher.queueToFetch({
 			post_id: $( '#post_ID' ).val(),
-			shortcode: this.shortcodeModel.formatShortcode(),
-			nonce: shortcodeUIData.nonces.preview,
+			shortcode: this.shortcodeModel.formatShortcode()
 		});
-	},
-
-	/**
-	 * Fetch a preview of a single shortcode.
-	 *
-	 * Async. Sets this.content and calls this.render.
-	 *
-	 * @return undefined
-	 */
-	fetch: function() {
-		var self = this;
-
-		if ( ! this.fetching ) {
-			this.fetching = true;
-
-			wp.ajax.post( 'do_shortcode', {
-				post_id: $( '#post_ID' ).val(),
-				shortcode: this.shortcodeModel.formatShortcode(),
-				nonce: shortcodeUIData.nonces.preview,
-			}).done( function( response ) {
-				if ( '' === response ) {
-					self.content = '<span class="shortcake-notice shortcake-empty">' + self.shortcodeModel.formatShortcode() + '</span>';
-				} else {
-					self.content = response;
-				}
-			}).fail( function() {
-				self.content = '<span class="shortcake-error">' + shortcodeUIData.strings.mce_view_error + '</span>';
-			} ).always( function() {
-				delete self.fetching;
-				self.render( null, true );
-			} );
-		}
 	},
 
 	/**


### PR DESCRIPTION
Following on from https://github.com/wp-shortcake/shortcake/pull/743#issuecomment-311819095

Removes the unused "fetch()" method from Shortcode View constructor (it was confusingly making a request to the 'do_shortcode' ajax endpoint, which was removed a long time ago). Also removes the nonce which is set with each separate query in the bulk_do_shortcode request - since #743, a single nonce is being sent as a top-level field on the request and is being checked by the 'bulk_do_shortcode' endpoint.

This is causing some test failures, because we have specs still testing the shortcode constructor.fetch() function. There's no reason to test this function since its no longer used, but I didn't want to remove the tests without replacing them with tests that cover the .delayedFetch() function, and that will take a bit of thought.