### PR TITLE
Submits all shortcode fields for AJAX searches.

### DIFF
--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -1851,7 +1851,8 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 						s         : params.term, // search term
 						page      : params.page,
 						shortcode : self.shortcode.get( 'shortcode_tag'),
-						attr      : self.model.get( 'attr' )
+						attr      : self.model.get( 'attr' ),
+						fields    : self.$el.parents('form').serialize()
 					}, self.ajaxData );
 				},
 				processResults: function (response, params) {

--- a/js/src/views/select2-field.js
+++ b/js/src/views/select2-field.js
@@ -117,7 +117,8 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 						s         : params.term, // search term
 						page      : params.page,
 						shortcode : self.shortcode.get( 'shortcode_tag'),
-						attr      : self.model.get( 'attr' )
+						attr      : self.model.get( 'attr' ),
+						fields    : self.$el.parents('form').serialize()
 					}, self.ajaxData );
 				},
 				processResults: function (response, params) {


### PR DESCRIPTION
When creating a custom Post Select field (that `extends` the existing `Shortcode_UI_Field_Post_Select` class) it would be very helpful to also send *all* other shortcode fields in the AJAX request.

A use case would be to allow users to customize the WP_Query args in the UI itself when searching for posts. For example, we can provide dropdowns for `date_query` options such as "After/Before", "-30 days, -7 days, -24 hours", etc.

It would be the responsibility of the shortcode class to sanitize and perform logic for the extra data. This shouldn't affect any existing shortcodes as the extra data would simply be ignored in the current AJAX callbacks.