### PR TITLE
Example of js hooks

### DIFF
--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -1851,7 +1851,8 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 						s         : params.term, // search term
 						page      : params.page,
 						shortcode : self.shortcode.get( 'shortcode_tag'),
-						attr      : self.model.get( 'attr' )
+						attr      : self.model.get( 'attr' ),
+						fields    : self.$el.parents('form').serialize()
 					}, self.ajaxData );
 				},
 				processResults: function (response, params) {

--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -1847,13 +1847,33 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 				dataType: 'json',
 				delay: 250,
 				data: function (params) {
+
+					var shortcode = self.shortcode.get( 'shortcode_tag' ),
+						attr = self.model.get( 'attr' ),
+						filterName = [ shortcode, attr, 'ajax-data' ].join('.'),
+						collection = _.flatten( _.values( self.views.parent.views._views ) );
+
+					/**
+					 * Filter any additional parameters sent along with search request.
+					 *
+					 * Called as `{shortcodeName}.{attributeName}.ajax-data`.
+					 *
+					 * @param ajaxData (object)
+					 *           Default fields sent with request
+					 * @param viewModels (array)
+					 *           The collections of views (editAttributeFields)
+					 *                         which make up this shortcode UI form
+					 * @param shortcode (object)
+					 *           Reference to the shortcode model which this attribute belongs to.
+					 */
+					var ajaxData = wp.shortcake.hooks.applyFilters( filterName, self.ajaxData, collection, self.shortcode );
+
 					return $.extend( {
 						s         : params.term, // search term
 						page      : params.page,
 						shortcode : self.shortcode.get( 'shortcode_tag'),
 						attr      : self.model.get( 'attr' ),
-						fields    : self.$el.parents('form').serialize()
-					}, self.ajaxData );
+					}, ajaxData );
 				},
 				processResults: function (response, params) {
 					if ( ! response.success || 'undefined' === typeof response.data ) {

--- a/js/src/views/select2-field.js
+++ b/js/src/views/select2-field.js
@@ -117,7 +117,8 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 						s         : params.term, // search term
 						page      : params.page,
 						shortcode : self.shortcode.get( 'shortcode_tag'),
-						attr      : self.model.get( 'attr' )
+						attr      : self.model.get( 'attr' ),
+						fields    : self.$el.parents('form').serialize()
 					}, self.ajaxData );
 				},
 				processResults: function (response, params) {

--- a/js/src/views/select2-field.js
+++ b/js/src/views/select2-field.js
@@ -113,13 +113,33 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 				dataType: 'json',
 				delay: 250,
 				data: function (params) {
+
+					var shortcode = self.shortcode.get( 'shortcode_tag' ),
+						attr = self.model.get( 'attr' ),
+						filterName = [ shortcode, attr, 'ajax-data' ].join('.'),
+						collection = _.flatten( _.values( self.views.parent.views._views ) );
+
+					/**
+					 * Filter any additional parameters sent along with search request.
+					 *
+					 * Called as `{shortcodeName}.{attributeName}.ajax-data`.
+					 *
+					 * @param ajaxData (object)
+					 *           Default fields sent with request
+					 * @param viewModels (array)
+					 *           The collections of views (editAttributeFields)
+					 *                         which make up this shortcode UI form
+					 * @param shortcode (object)
+					 *           Reference to the shortcode model which this attribute belongs to.
+					 */
+					var ajaxData = wp.shortcake.hooks.applyFilters( filterName, self.ajaxData, collection, self.shortcode );
+
 					return $.extend( {
 						s         : params.term, // search term
 						page      : params.page,
 						shortcode : self.shortcode.get( 'shortcode_tag'),
 						attr      : self.model.get( 'attr' ),
-						fields    : self.$el.parents('form').serialize()
-					}, self.ajaxData );
+					}, ajaxData );
 				},
 				processResults: function (response, params) {
 					if ( ! response.success || 'undefined' === typeof response.data ) {


### PR DESCRIPTION
Example of js hook in post select ajax data, see discussion in https://github.com/wp-shortcake/shortcake/pull/767#issuecomment-325024495

With this in place, you would filter the data being sent with the ajax request something like

```
wp.shortcake.hooks.addFilter( 'shortcode_tag.attr.ajax-data', function addParams( response ) {
  response.date_query = $( date_query_field ).value;
  return response;
} )
```

and add any new arguments to the return value you want.