### PR TITLE
Adds `shortcode_ui_preview` filter

### DIFF
--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -440,6 +440,25 @@ class Shortcode_UI {
 			// @codingStandardsIgnoreEnd
 		}
 
+		// Get the Shortcode tag and set the response if any
+		preg_match_all( '@\[([^<>&/\[\]\x00-\x20=]++)@', $shortcode, $matches );
+		$shortcode_tag = isset( $matches[1][0] ) ? $matches[1][0] : '';
+
+		/**
+		 * Filter the shortcode preview
+		 *
+		 * Used to render a custom preview for the shortcodes on the editor
+		 *
+		 * @param string $pre_option    The default value to return if the custom preview hasn't been set.
+		 * @param string $shortcode_tag Shortcode tag name.
+		 * @param string $shortcode     Shortcode used.
+		 * @param array  $options       Shortcode UI options for the shortcode tag
+		 */
+		$response = apply_filters( 'shortcode_ui_preview', false, $shortcode_tag, $shortcode, $this->get_shortcode( $shortcode_tag ) );
+		if ( false !== $response ) {
+			return $response;
+		}
+
 		ob_start();
 		/**
 		 * Fires before shortcode is rendered in preview.


### PR DESCRIPTION
Added `shortcode_ui_preview` filter to give the option to modify the preview in the WYSIWYG.

Some people want to have the option not to preview the content parsed in the editor because they might break the content, or use the dashicons instead. 

The filter added will allow them to do that: 

```php 
// $options = Shortcode UI Options
add_filter('shortcode_ui_preview', function($return, $shortcode_tag, $shortcode, $options) { 
    if($shortcode_tag == 'special_shortcode_tag') {
         return '<img src="/path/to/image">';
    }

    return sprintf( '<span class="dashicons %s"></span> %s', $options['listItemImage'], $options['label']);
}, 10, 4);
```