### PR TITLE
Remove PHP 5.2 from Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,13 @@ language: php
 
 matrix:
   include:
-    - php: 5.2
-      env: WP_VERSION=latest WP_MULTISITE=0 WP_TRAVISCI=travis:phpunit
     - php: 5.6
       env: WP_VERSION=latest WP_MULTISITE=0 WP_TRAVISCI=travis:phpunit
-    - php: 5.6
+    - php: 7.1
       env: WP_VERSION=latest WP_MULTISITE=1 WP_TRAVISCI=travis:phpunit
     - php: 5.6
       env: WP_TRAVISCI=travis:js-tests
-    - php: 5.6
+    - php: 7.1
       env: WP_TRAVISCI=travis:php-lint
 
 cache:

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -69,7 +69,7 @@ install_test_suite() {
 	# set up testing suite if it doesn't yet exist
 	if [ ! -d $WP_TESTS_DIR ]; then
 		# set up testing suite
-		mkdir -p $WP_TESTS_DIR
+		mkdir -p $WP_TESTS_DIR/data/themedir1
 		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
 	fi
 

--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -261,8 +261,8 @@ class Shortcode_UI {
 		);
 
 		if ( 'select2' !== self::$select2_handle ) {
-			 wp_add_inline_script( self::$select2_handle, 'var existingSelect2 = jQuery.fn.select2 || null; if (existingSelect2) { delete jQuery.fn.select2; }', 'before' );
-			 wp_add_inline_script( self::$select2_handle, 'jQuery.fn[ shortcodeUIData.select2_handle ] = jQuery.fn.select2; if (existingSelect2) { delete jQuery.fn.select2; jQuery.fn.select2 = existingSelect2; }', 'after' );
+			wp_add_inline_script( self::$select2_handle, 'var existingSelect2 = jQuery.fn.select2 || null; if (existingSelect2) { delete jQuery.fn.select2; }', 'before' );
+			wp_add_inline_script( self::$select2_handle, 'jQuery.fn[ shortcodeUIData.select2_handle ] = jQuery.fn.select2; if (existingSelect2) { delete jQuery.fn.select2; jQuery.fn.select2 = existingSelect2; }', 'after' );
 		}
 
 		wp_register_style( self::$select2_handle,


### PR DESCRIPTION
There's no reason we need to be testing against PHP 5.2, and since it's
not pre-installed on Travis any more, it's just causing our tests to
error out. Removing that from the matrix and adding PHP 7.1, which is
actually relevant.