### PR TITLE
Differentiate selected terms by slug and taxonomy

### DIFF
--- a/inc/fields/class-shortcode-ui-field-post-select.php
+++ b/inc/fields/class-shortcode-ui-field-post-select.php
@@ -143,11 +143,12 @@ class Shortcode_UI_Field_Post_Select {
 			$post_type     = get_post_type( $post_id );
 			$post_type_obj = get_post_type_object( $post_type );
 
-			$text = html_entity_decode( get_the_title( $post_id ) . ' - ' . get_post_field( 'post_name', $post_id ) );
+			$text = html_entity_decode( get_the_title( $post_id ) );
 
 			if ( $is_multiple_post_types && $post_type_obj ) {
-				$text .= sprintf( ' (%1$s)', $post_type_obj->labels->singular_name );
+				$text .= sprintf( '- %1$s (%2$s)', get_post_field( 'post_name', $post_id ), $post_type_obj->labels->singular_name );
 			}
+
 			array_push( $response['items'],
 				array(
 					'id'   => $post_id,

--- a/inc/fields/class-shortcode-ui-field-post-select.php
+++ b/inc/fields/class-shortcode-ui-field-post-select.php
@@ -58,15 +58,15 @@ class Shortcode_UI_Field_Post_Select {
 
 		?>
 
-		<script type="text/html" id="tmpl-shortcode-ui-field-post-select">
-			<div class="field-block shortcode-ui-field-post-select shortcode-ui-attribute-{{ data.attr }}">
-				<label for="{{ data.id }}">{{{ data.label }}}</label>
-				<select id="{{ data.id }}" name="{{ data.name }}" class="shortcode-ui-post-select" ></select>
-				<# if ( typeof data.description == 'string' && data.description.length ) { #>
-					<p class="description">{{{ data.description }}}</p>
-				<# } #>
-			</div>
-		</script>
+      <script type="text/html" id="tmpl-shortcode-ui-field-post-select">
+        <div class="field-block shortcode-ui-field-post-select shortcode-ui-attribute-{{ data.attr }}">
+          <label for="{{ data.id }}">{{{ data.label }}}</label>
+          <select id="{{ data.id }}" name="{{ data.name }}" class="shortcode-ui-post-select" ></select>
+          <# if ( typeof data.description == 'string' && data.description.length ) { #>
+            <p class="description">{{{ data.description }}}</p>
+            <# } #>
+        </div>
+      </script>
 
 		<?php
 	}

--- a/inc/fields/class-shortcode-ui-field-post-select.php
+++ b/inc/fields/class-shortcode-ui-field-post-select.php
@@ -143,7 +143,7 @@ class Shortcode_UI_Field_Post_Select {
 			$post_type     = get_post_type( $post_id );
 			$post_type_obj = get_post_type_object( $post_type );
 
-			$text = html_entity_decode( get_the_title( $post_id ) );
+			$text = html_entity_decode( get_the_title( $post_id ) . ' - ' . get_post_field( 'post_name', $post_id ) );
 
 			if ( $is_multiple_post_types && $post_type_obj ) {
 				$text .= sprintf( ' (%1$s)', $post_type_obj->labels->singular_name );

--- a/inc/fields/class-shortcode-ui-field-term-select.php
+++ b/inc/fields/class-shortcode-ui-field-term-select.php
@@ -67,15 +67,15 @@ class Shortcode_UI_Field_Term_Select {
 
 		?>
 
-		<script type="text/html" id="tmpl-shortcode-ui-field-term-select">
-			<div class="field-block shortcode-ui-field-term-select shortcode-ui-attribute-{{ data.attr }}">
-				<label for="{{ data.id }}">{{{ data.label }}}</label>
-				<select name="{{ data.attr }}" id="{{ data.id }}" class="shortcode-ui-term-select"></select>
-				<# if ( typeof data.description == 'string' && data.description.length ) { #>
-					<p class="description">{{{ data.description }}}</p>
-				<# } #>
-			</div>
-		</script>
+      <script type="text/html" id="tmpl-shortcode-ui-field-term-select">
+        <div class="field-block shortcode-ui-field-term-select shortcode-ui-attribute-{{ data.attr }}">
+          <label for="{{ data.id }}">{{{ data.label }}}</label>
+          <select name="{{ data.attr }}" id="{{ data.id }}" class="shortcode-ui-term-select"></select>
+          <# if ( typeof data.description == 'string' && data.description.length ) { #>
+            <p class="description">{{{ data.description }}}</p>
+            <# } #>
+        </div>
+      </script>
 
 		<?php
 	}
@@ -148,10 +148,10 @@ class Shortcode_UI_Field_Term_Select {
 			$response['terms_per_page'] = 10;
 		}
 
-    // wp_count_terms relies on a string and uses the get_terms method anyway, so let's just cut to the chase
-    $num_results = get_terms( $taxonomy_type, array_merge( $args, [
-      'fields' => 'count',
-    ] ) );
+		// wp_count_terms relies on a string and uses the get_terms method anyway, so let's just cut to the chase
+		$num_results = get_terms( $taxonomy_type, array_merge( $args, [
+			'fields' => 'count',
+		] ) );
 
 		if ( empty( $num_results ) ) {
 			wp_send_json_error();
@@ -164,29 +164,29 @@ class Shortcode_UI_Field_Term_Select {
 			$args['offset'] = ( $page - 1 ) * $response['items_per_page'];
 		}
 
-    $is_multiple_taxonomies = count( $args['taxonomy'] ) > 1;
+		$is_multiple_taxonomies = count( $args['taxonomy'] ) > 1;
 		$taxonomies = [];
 		if ( $is_multiple_taxonomies )
-    {
-      foreach ( $args['taxonomy'] as $tax_slug )
-      {
-        $taxonomies[ $tax_slug ] = get_taxonomy( $tax_slug );
-      }
-    }
+		{
+			foreach ( $args['taxonomy'] as $tax_slug )
+			{
+				$taxonomies[ $tax_slug ] = get_taxonomy( $tax_slug );
+			}
+		}
 
 		$results = get_terms( $args );
 
 		foreach ( $results as $result ) {
-		  $text = html_entity_decode( $result->name );
+			$text = html_entity_decode( $result->name );
 
-      if ( $is_multiple_taxonomies ) {
+			if ( $is_multiple_taxonomies ) {
 				$text .= sprintf( ' - %1%s (%2$s)', $result->slug, $taxonomies[ $result->taxonomy ]->labels->singular_name );
 			}
 
 			array_push( $response['items'],
 				array(
 					'id'   => $result->term_id,
-          'text' => $text,
+					'text' => $text,
 				)
 			);
 		}

--- a/inc/fields/class-shortcode-ui-field-term-select.php
+++ b/inc/fields/class-shortcode-ui-field-term-select.php
@@ -164,13 +164,29 @@ class Shortcode_UI_Field_Term_Select {
 			$args['offset'] = ( $page - 1 ) * $response['items_per_page'];
 		}
 
+    $is_multiple_taxonomies = count( $args['taxonomy'] ) > 1;
+		$taxonomies = [];
+		if ( $is_multiple_taxonomies )
+    {
+      foreach ( $args['taxonomy'] as $tax_slug )
+      {
+        $taxonomies[ $tax_slug ] = get_taxonomy( $tax_slug );
+      }
+    }
+
 		$results = get_terms( $args );
 
 		foreach ( $results as $result ) {
+		  $text = html_entity_decode( $result->name );
+
+      if ( $is_multiple_taxonomies ) {
+				$text .= sprintf( ' - %1%s (%2$s)', $result->slug, $taxonomies[ $result->taxonomy ]->labels->singular_name );
+			}
+
 			array_push( $response['items'],
 				array(
 					'id'   => $result->term_id,
-          'text' => html_entity_decode( $result->name . ' - ' . $result->slug . ' (' . $result->taxonomy . ')' ),
+          'text' => $text,
 				)
 			);
 		}

--- a/inc/fields/class-shortcode-ui-field-term-select.php
+++ b/inc/fields/class-shortcode-ui-field-term-select.php
@@ -148,7 +148,10 @@ class Shortcode_UI_Field_Term_Select {
 			$response['terms_per_page'] = 10;
 		}
 
-		$num_results = wp_count_terms( $taxonomy_type, $args );
+    // wp_count_terms relies on a string and uses the get_terms method anyway, so let's just cut to the chase
+    $num_results = get_terms( $taxonomy_type, array_merge( $args, [
+      'fields' => 'count',
+    ] ) );
 
 		if ( empty( $num_results ) ) {
 			wp_send_json_error();
@@ -167,7 +170,7 @@ class Shortcode_UI_Field_Term_Select {
 			array_push( $response['items'],
 				array(
 					'id'   => $result->term_id,
-					'text' => html_entity_decode( $result->name ),
+          'text' => html_entity_decode( $result->name . ' - ' . $result->slug . ' (' . $result->taxonomy . ')' ),
 				)
 			);
 		}


### PR DESCRIPTION
I added in a way to differentiate terms by slug and taxonomy, much like the post_select has a way to differentiate by post type. I often have a number of categories with the same name (e.g. same named categories for men's and women's products on sale) so required the further differentiation.

Additionally, `wp_count_terms` uses `get_terms` anyway, so I edited it to work better with IDEs like PHPStorm which complain about `wp_count_terms` requiring `$taxonomy_type` to be a string.