### PR TITLE
Decoding of attributes not working 

### DIFF
--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -506,16 +506,15 @@ class Shortcode_UI {
 
 		// Get current shortcode tag from the current filter
 		// by stripping `shortcode_atts_` from start of string.
-		$shortcode_tag = substr( current_filter(), 15 );
-
-		if ( ! isset( $this->shortcodes[ $shortcode_tag ] ) ) {
+		$shortcode_tag  = substr( current_filter(), 15 );
+		$shortcode_args = $this->get_shortcode( $shortcode_tag );
+		if ( ! $shortcode_args ) {
 			return $out;
 		}
 
 		$fields = Shortcode_UI_Fields::get_instance()->get_fields();
-		$args   = $this->shortcodes[ $shortcode_tag ];
 
-		foreach ( $args['attrs'] as $attr ) {
+		foreach ( $shortcode_args['attrs'] as $attr ) {
 
 			$default = isset( $fields[ $attr['type'] ]['encode'] ) ? $fields[ $attr['type'] ]['encode'] : false;
 			$encoded = isset( $attr['encode'] ) ? $attr['encode'] : $default;


### PR DESCRIPTION
When we set the encode attribute to any field, the values are encoded and stored in the database but the decode is not working in the post edit screen or the front end. The reason for that is the action `register_shortcode_ui` is called from https://github.com/wp-shortcake/shortcake/blob/master/inc/class-shortcode-ui.php#L81 and it will hook the filter here https://github.com/wp-shortcake/shortcake/blob/master/inc/class-shortcode-ui.php#L170. The filter is not called every time. It causes issues with decoding.

The PR does not actually solves the problem but it will enable developers to register the filter outside of the plugin. The decode function is not working when we hook it because it uses the private variable to get the shortcodes. The PR changes modifies it to use the function. 