### PR TITLE
Fix js uncaught TypeError

### DIFF
--- a/js/src/views/edit-attribute-field.js
+++ b/js/src/views/edit-attribute-field.js
@@ -50,7 +50,7 @@ var editAttributeField = Backbone.View.extend( {
 		// Ensure default value for select field.
 		if ( 'select' === data.type && '' === this.model.get( 'value' ) && ! _.findWhere( data.options, { value: '' } ) ) {
 			var firstVisibleOption = _.first( data.options );
-			if ( 'undefined' !== typeof firstVisibleOption.value ) {
+			if ( firstVisibleOption && 'undefined' !== typeof firstVisibleOption.value ) {
 				this.setValue( firstVisibleOption.value );
 				data.value = firstVisibleOption.value;
 			}


### PR DESCRIPTION
Fix js uncaught TypeError when no options have been supplied to the field causing firstVisibleOption to be undefined. This resulted to a blank Insert Post Element popup when clicking on an element that contained such field.