### PR TITLE
Re-initialize uploader after resetting media controller

### DIFF
--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -106,6 +106,7 @@ var MediaController = wp.media.controller.State.extend({
 		menuItem.render();
 
 		this.frame.setState( 'insert' );
+		this.frame.uploader.uploader.uploader.init();
 	},
 
 	setActionSelect: function() {

--- a/js/src/controllers/media-controller.js
+++ b/js/src/controllers/media-controller.js
@@ -69,6 +69,7 @@ var MediaController = wp.media.controller.State.extend({
 		menuItem.render();
 
 		this.frame.setState( 'insert' );
+		this.frame.uploader.uploader.uploader.init();
 	},
 
 	setActionSelect: function() {


### PR DESCRIPTION
Fixes issue with 'Select Files' button within the 'Upload Media' view, as discussed in #788.

Was hoping for something less hacky, but I too couldn't find a solution that worked.
