### PR TITLE
Avoid outputting duplicate underscore templates

### DIFF
--- a/inc/fields/class-shortcode-ui-field-attachment.php
+++ b/inc/fields/class-shortcode-ui-field-attachment.php
@@ -55,7 +55,6 @@ class Shortcode_UI_Field_Attachment {
 	private function setup_actions() {
 		add_filter( 'shortcode_ui_fields', array( $this, 'filter_shortcode_ui_fields' ) );
 		add_action( 'enqueue_shortcode_ui', array( $this, 'action_enqueue_shortcode_ui' ) );
-		add_action( 'shortcode_ui_loaded_editor', array( $this, 'action_shortcode_ui_loaded_editor' ) );
 	}
 
 	/**
@@ -69,10 +68,10 @@ class Shortcode_UI_Field_Attachment {
 	}
 
 	/**
-	 * Add localization data needed for Shortcode UI Attachment Field
+	 * Add localization data needed for Shortcode UI Attachment Field, and
+	 * enqueue templates to be output in the footer.
 	 */
 	public function action_enqueue_shortcode_ui() {
-
 		wp_localize_script(
 			'shortcode-ui', 'ShortcakeImageFieldData', array(
 				'defaultArgs' => array(
@@ -82,15 +81,15 @@ class Shortcode_UI_Field_Attachment {
 				),
 			)
 		);
+
+		add_action( 'admin_print_footer_scripts', array( $this, 'action_admin_print_footer_scripts' ) );
 	}
 
 	/**
 	 * Output templates used by post select field.
 	 */
-	public function action_shortcode_ui_loaded_editor() {
-
+	public function action_admin_print_footer_scripts() {
 		?>
-
 		<script type="text/html" id="tmpl-fusion-shortcake-field-attachment">
 			<div class="field-block shortcode-ui-field-attachment shortcode-ui-attribute-{{ data.attr }}">
 				<label for="{{ data.attr }}">{{{ data.label }}}</label>
@@ -101,7 +100,6 @@ class Shortcode_UI_Field_Attachment {
 				<div class="attachment-previews"></div>
 			</div>
 		</script>
-
 		<script type="text/html" id="tmpl-shortcake-image-preview">
 			<div class="shortcake-attachment-preview">
 				<div class="shortcake-attachment-preview-container attachment-preview attachment <# if ( data.type === 'image' && ! data.sizes ) { #>loading<# } #>">
@@ -133,9 +131,7 @@ class Shortcode_UI_Field_Attachment {
 							<div class="attachment-preview-loading"><ins></ins></div>
 						</div>
 					<# } #>
-
 				</div>
-
 				<div class="thumbnail-details-container has-attachment">
 					<strong><?php esc_html_e( 'Attachment Details', 'shortcode-ui' ); ?></strong>
 					<div class="filename">{{ data.filename }}</div>
@@ -148,7 +144,6 @@ class Shortcode_UI_Field_Attachment {
 				</div>
 			</div>
 		</script>
-
 		<?php
 	}
 

--- a/inc/fields/class-shortcode-ui-field-color.php
+++ b/inc/fields/class-shortcode-ui-field-color.php
@@ -54,7 +54,7 @@ class Shortcode_UI_Field_Color {
 	 */
 	private function setup_actions() {
 		add_filter( 'shortcode_ui_fields', array( $this, 'filter_shortcode_ui_fields' ) );
-		add_action( 'shortcode_ui_loaded_editor', array( $this, 'load_template' ) );
+		add_action( 'enqueue_shortcode_ui', array( $this, 'action_enqueue_shortcode_ui' ) );
 	}
 
 	/**
@@ -95,10 +95,10 @@ class Shortcode_UI_Field_Color {
 	}
 
 	/**
-	 * Output templates used by the color field.
+	 * Enqueue necessary scripts and styles, if required, and enqueue template
+	 * to be output in the footer.
 	 */
-	public function load_template() {
-
+	public function action_enqueue_shortcode_ui() {
 		if ( ! $this->color_attribute_present() ) {
 			return;
 		}
@@ -106,8 +106,14 @@ class Shortcode_UI_Field_Color {
 		wp_enqueue_script( 'wp-color-picker' );
 		wp_enqueue_style( 'wp-color-picker' );
 
-		?>
+		add_action( 'admin_print_footer_scripts', array( $this, 'action_admin_print_footer_scripts' ) );
+	}
 
+	/**
+	 * Output the field template.
+	 */
+	public function action_admin_print_footer_scripts() {
+		?>
 		<script type="text/html" id="tmpl-fusion-shortcake-field-color">
 			<div class="field-block shortcode-ui-field-color shortcode-ui-attribute-{{ data.attr }}">
 				<label for="{{ data.attr }}">{{{ data.label }}}</label>
@@ -117,8 +123,6 @@ class Shortcode_UI_Field_Color {
 				<# } #>
 			</div>
 		</script>
-
 		<?php
 	}
-
 }

--- a/inc/fields/class-shortcode-ui-field-post-select.php
+++ b/inc/fields/class-shortcode-ui-field-post-select.php
@@ -28,18 +28,20 @@ class Shortcode_UI_Field_Post_Select {
 	}
 
 	private function setup_actions() {
-
 		add_filter( 'shortcode_ui_fields', array( $this, 'filter_shortcode_ui_fields' ) );
 		add_action( 'enqueue_shortcode_ui', array( $this, 'action_enqueue_shortcode_ui' ) );
 		add_action( 'wp_ajax_shortcode_ui_post_field', array( $this, 'action_wp_ajax_shortcode_ui_post_field' ) );
 		add_action( 'shortcode_ui_loaded_editor', array( $this, 'action_shortcode_ui_loaded_editor' ) );
-
 	}
 
 	public function filter_shortcode_ui_fields( $fields ) {
 		return array_merge( $fields, $this->fields );
 	}
 
+	/**
+	 * Enqueue Select2, create localization data, and enqueue template to be
+	 * output in the footer.
+	 */
 	public function action_enqueue_shortcode_ui() {
 
 		wp_enqueue_script( Shortcode_UI::$select2_handle );
@@ -51,15 +53,14 @@ class Shortcode_UI_Field_Post_Select {
 			)
 		);
 
+		add_action( 'admin_print_footer_scripts', array( $this, 'action_admin_print_footer_scripts' ) );
 	}
 
 	/**
-	 * Output styles and templates used by post select field.
+	 * Output template used by post select field.
 	 */
-	public function action_shortcode_ui_loaded_editor() {
-
+	public function action_admin_print_footer_scripts() {
 		?>
-
 		<script type="text/html" id="tmpl-shortcode-ui-field-post-select">
 			<div class="field-block shortcode-ui-field-post-select shortcode-ui-attribute-{{ data.attr }}">
 				<label for="{{ data.id }}">{{{ data.label }}}</label>
@@ -69,7 +70,6 @@ class Shortcode_UI_Field_Post_Select {
 				<# } #>
 			</div>
 		</script>
-
 		<?php
 	}
 

--- a/inc/fields/class-shortcode-ui-field-term-select.php
+++ b/inc/fields/class-shortcode-ui-field-term-select.php
@@ -34,7 +34,6 @@ class Shortcode_UI_Field_Term_Select {
 		add_filter( 'shortcode_ui_fields', array( $this, 'filter_shortcode_ui_fields' ) );
 		add_action( 'enqueue_shortcode_ui', array( $this, 'action_enqueue_shortcode_ui' ) );
 		add_action( 'wp_ajax_shortcode_ui_term_field', array( $this, 'action_wp_ajax_shortcode_ui_term_field' ) );
-		add_action( 'shortcode_ui_loaded_editor', array( $this, 'action_shortcode_ui_loaded_editor' ) );
 	}
 
 	/**
@@ -48,7 +47,7 @@ class Shortcode_UI_Field_Term_Select {
 	}
 
 	/**
-	 * Add Select2 for our UI.
+	 * Add Select2 for our UI, and enqueue templates.
 	 */
 	public function action_enqueue_shortcode_ui() {
 
@@ -60,15 +59,15 @@ class Shortcode_UI_Field_Term_Select {
 				'nonce' => wp_create_nonce( 'shortcode_ui_field_term_select' ),
 			)
 		);
+
+		add_action( 'admin_print_footer_scripts', array( $this, 'action_admin_print_footer_scripts' ) );
 	}
 
 	/**
 	 * Output styles and templates used by post select field.
 	 */
-	public function action_shortcode_ui_loaded_editor() {
-
+	public function action_admin_print_footer_scripts() {
 		?>
-
 		<script type="text/html" id="tmpl-shortcode-ui-field-term-select">
 			<div class="field-block shortcode-ui-field-term-select shortcode-ui-attribute-{{ data.attr }}">
 				<label for="{{ data.id }}">{{{ data.label }}}</label>

--- a/inc/fields/class-shortcode-ui-field-user-select.php
+++ b/inc/fields/class-shortcode-ui-field-user-select.php
@@ -38,7 +38,6 @@ class Shortcode_UI_Field_User_Select {
 		add_action( 'enqueue_shortcode_ui', array( $this, 'action_enqueue_shortcode_ui' ) );
 		add_action( 'wp_ajax_shortcode_ui_user_field', array( $this, 'action_wp_ajax_shortcode_ui_user_field' ) );
 		add_action( 'wp_ajax_shortcode_ui_user_field_preselect', array( $this, 'action_wp_ajax_shortcode_ui_user_field_preselect' ) );
-		add_action( 'shortcode_ui_loaded_editor', array( $this, 'action_shortcode_ui_loaded_editor' ) );
 	}
 
 	/**
@@ -54,7 +53,7 @@ class Shortcode_UI_Field_User_Select {
 	}
 
 	/**
-	 * Add Select2 for our UI.
+	 * Add Select2 for our UI, and enqueue field templates.
 	 */
 	public function action_enqueue_shortcode_ui() {
 
@@ -66,12 +65,14 @@ class Shortcode_UI_Field_User_Select {
 				'nonce' => wp_create_nonce( 'shortcode_ui_field_user_select' ),
 			)
 		);
+
+		add_action( 'admin_print_footer_scripts', array( $this, 'action_admin_print_footer_scripts' ) );
 	}
 
 	/**
-	 * Output styles and templates used by user select field.
+	 * Output templates used by user select field.
 	 */
-	public function action_shortcode_ui_loaded_editor() {
+	public function action_admin_print_footer_scripts() {
 		?>
 
 		<script type="text/html" id="tmpl-shortcode-ui-field-user-select">


### PR DESCRIPTION
Many of the attribute fields in this plugin were outputting their templates on the `shortcode_ui_loaded_editor` hook, which fires every time an editor is created. As a result, duplicate templates were being created with identical IDs when an edit screen contained more than one WP_Editor.

This PR addresses that problem by moving the template enqueues to the `enqueue_shortcode_ui` hook, which only fires once per page load, and from that hook, adding the template output functions onto the admin_print_footer_scripts hook, so that they show up in a reasonable place rather than in the middle of the page markup.