### PR TITLE
Add allowClear property to select2 inputs

### DIFF
--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -1856,7 +1856,10 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 	render: function() {
 
 		var self = this,
-			defaults = { multiple: false };
+			defaults = { 
+				multiple: false,
+				allowClear: false
+			};
 
 		for ( var arg in defaults ) {
 			if ( ! this.model.get( arg ) ) {
@@ -1876,6 +1879,7 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 		var $fieldSelect2 = $field[ shortcodeUIData.select2_handle ]({
 			placeholder: "Search",
 			multiple: this.model.get( 'multiple' ),
+			allowClear: this.model.get( 'allowClear' ),
 			dropdownParent: this.$el,
 
 			ajax: {

--- a/js/src/views/select2-field.js
+++ b/js/src/views/select2-field.js
@@ -91,7 +91,10 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 	render: function() {
 
 		var self = this,
-			defaults = { multiple: false };
+			defaults = { 
+				multiple: false,
+				allowClear: false
+			};
 
 		for ( var arg in defaults ) {
 			if ( ! this.model.get( arg ) ) {
@@ -111,6 +114,7 @@ sui.views.editAttributeSelect2Field = sui.views.editAttributeField.extend( {
 		var $fieldSelect2 = $field[ shortcodeUIData.select2_handle ]({
 			placeholder: "Search",
 			multiple: this.model.get( 'multiple' ),
+			allowClear: this.model.get( 'allowClear' ),
 			dropdownParent: this.$el,
 
 			ajax: {


### PR DESCRIPTION
Add the select2 property `allowClear` to select2 input fields. Set default value to false (since it's currently not included, though it may be better as set to true). 

This fixes issue 610 https://github.com/wp-shortcake/shortcake/issues/610