### PR TITLE
Avoid outputting underscore templates before the opening <doctype> tag

### DIFF
--- a/inc/fields/class-shortcode-ui-field-attachment.php
+++ b/inc/fields/class-shortcode-ui-field-attachment.php
@@ -89,7 +89,7 @@ class Shortcode_UI_Field_Attachment {
 	 */
 	public function action_shortcode_ui_loaded_editor() {
 		add_action( 'admin_print_footer_scripts', array( $this, 'output_templates' ) );
-    }
+	}
 
 	/**
 	 * Output templates used by attachment field.

--- a/inc/fields/class-shortcode-ui-field-attachment.php
+++ b/inc/fields/class-shortcode-ui-field-attachment.php
@@ -85,10 +85,16 @@ class Shortcode_UI_Field_Attachment {
 	}
 
 	/**
-	 * Output templates used by post select field.
+	 * Prepare to output the templates required for this field in the footer.
 	 */
 	public function action_shortcode_ui_loaded_editor() {
+		add_action( 'admin_print_footer_scripts', array( $this, 'output_templates' ) );
+    }
 
+	/**
+	 * Output templates used by attachment field.
+	 */
+	public function output_templates() {
 		?>
 
 		<script type="text/html" id="tmpl-fusion-shortcake-field-attachment">
@@ -151,5 +157,4 @@ class Shortcode_UI_Field_Attachment {
 
 		<?php
 	}
-
 }

--- a/inc/fields/class-shortcode-ui-field-color.php
+++ b/inc/fields/class-shortcode-ui-field-color.php
@@ -54,7 +54,7 @@ class Shortcode_UI_Field_Color {
 	 */
 	private function setup_actions() {
 		add_filter( 'shortcode_ui_fields', array( $this, 'filter_shortcode_ui_fields' ) );
-		add_action( 'shortcode_ui_loaded_editor', array( $this, 'load_template' ) );
+		add_action( 'shortcode_ui_loaded_editor', array( $this, 'action_shortcode_ui_loaded_editor' ) );
 	}
 
 	/**
@@ -95,9 +95,9 @@ class Shortcode_UI_Field_Color {
 	}
 
 	/**
-	 * Output templates used by the color field.
+	 * Prepare to output the templates required for this field in the footer.
 	 */
-	public function load_template() {
+	public function action_shortcode_ui_loaded_editor() {
 
 		if ( ! $this->color_attribute_present() ) {
 			return;
@@ -106,16 +106,23 @@ class Shortcode_UI_Field_Color {
 		wp_enqueue_script( 'wp-color-picker' );
 		wp_enqueue_style( 'wp-color-picker' );
 
+		add_action( 'admin_print_footer_scripts', array( $this, 'output_templates' ) );
+	}
+
+	/**
+	 * Output templates used by the color field.
+	 */
+	public function output_templates() {
 		?>
 
 		<script type="text/html" id="tmpl-fusion-shortcake-field-color">
-			<div class="field-block shortcode-ui-field-color shortcode-ui-attribute-{{ data.attr }}">
-				<label for="{{ data.attr }}">{{{ data.label }}}</label>
-				<input type="text" name="{{ data.attr }}" id="{{ data.attr }}" value="{{ data.value }}" data-default-color="{{ data.value }}" {{{ data.meta }}}/>
-				<# if ( typeof data.description == 'string' && data.description.length ) { #>
-					<p class="description">{{{ data.description }}}</p>
-				<# } #>
-			</div>
+		<div class="field-block shortcode-ui-field-color shortcode-ui-attribute-{{ data.attr }}">
+			<label for="{{ data.attr }}">{{{ data.label }}}</label>
+			<input type="text" name="{{ data.attr }}" id="{{ data.attr }}" value="{{ data.value }}" data-default-color="{{ data.value }}" {{{ data.meta }}}/>
+			<# if ( typeof data.description == 'string' && data.description.length ) { #>
+				<p class="description">{{{ data.description }}}</p>
+			<# } #>
+		</div>
 		</script>
 
 		<?php

--- a/inc/fields/class-shortcode-ui-field-color.php
+++ b/inc/fields/class-shortcode-ui-field-color.php
@@ -116,13 +116,13 @@ class Shortcode_UI_Field_Color {
 		?>
 
 		<script type="text/html" id="tmpl-fusion-shortcake-field-color">
-		<div class="field-block shortcode-ui-field-color shortcode-ui-attribute-{{ data.attr }}">
-			<label for="{{ data.attr }}">{{{ data.label }}}</label>
-			<input type="text" name="{{ data.attr }}" id="{{ data.attr }}" value="{{ data.value }}" data-default-color="{{ data.value }}" {{{ data.meta }}}/>
-			<# if ( typeof data.description == 'string' && data.description.length ) { #>
-				<p class="description">{{{ data.description }}}</p>
-			<# } #>
-		</div>
+			<div class="field-block shortcode-ui-field-color shortcode-ui-attribute-{{ data.attr }}">
+				<label for="{{ data.attr }}">{{{ data.label }}}</label>
+				<input type="text" name="{{ data.attr }}" id="{{ data.attr }}" value="{{ data.value }}" data-default-color="{{ data.value }}" {{{ data.meta }}}/>
+				<# if ( typeof data.description == 'string' && data.description.length ) { #>
+					<p class="description">{{{ data.description }}}</p>
+				<# } #>
+			</div>
 		</script>
 
 		<?php

--- a/inc/fields/class-shortcode-ui-field-post-select.php
+++ b/inc/fields/class-shortcode-ui-field-post-select.php
@@ -54,10 +54,16 @@ class Shortcode_UI_Field_Post_Select {
 	}
 
 	/**
-	 * Output styles and templates used by post select field.
+	 * Prepare to output the templates required for this field in the footer.
 	 */
 	public function action_shortcode_ui_loaded_editor() {
+		add_action( 'admin_print_footer_scripts', array( $this, 'output_templates' ) );
+    }
 
+	/**
+	 * Output styles and templates used by post select field.
+	 */
+	public function output_templates() {
 		?>
 
 		<script type="text/html" id="tmpl-shortcode-ui-field-post-select">

--- a/inc/fields/class-shortcode-ui-field-term-select.php
+++ b/inc/fields/class-shortcode-ui-field-term-select.php
@@ -63,10 +63,16 @@ class Shortcode_UI_Field_Term_Select {
 	}
 
 	/**
-	 * Output styles and templates used by post select field.
+	 * Prepare to output the templates required for this field in the footer.
 	 */
 	public function action_shortcode_ui_loaded_editor() {
+		add_action( 'admin_print_footer_scripts', array( $this, 'output_templates' ) );
+    }
 
+	/**
+	 * Output styles and templates used by term select field.
+	 */
+	public function output_templates() {
 		?>
 
 		<script type="text/html" id="tmpl-shortcode-ui-field-term-select">

--- a/inc/fields/class-shortcode-ui-field-term-select.php
+++ b/inc/fields/class-shortcode-ui-field-term-select.php
@@ -67,7 +67,7 @@ class Shortcode_UI_Field_Term_Select {
 	 */
 	public function action_shortcode_ui_loaded_editor() {
 		add_action( 'admin_print_footer_scripts', array( $this, 'output_templates' ) );
-    }
+	}
 
 	/**
 	 * Output styles and templates used by term select field.

--- a/inc/fields/class-shortcode-ui-field-user-select.php
+++ b/inc/fields/class-shortcode-ui-field-user-select.php
@@ -73,7 +73,7 @@ class Shortcode_UI_Field_User_Select {
 	 */
 	public function action_shortcode_ui_loaded_editor() {
 		add_action( 'admin_print_footer_scripts', array( $this, 'output_templates' ) );
-    }
+	}
 
 	/**
 	 * Output templates used by user select field.

--- a/inc/fields/class-shortcode-ui-field-user-select.php
+++ b/inc/fields/class-shortcode-ui-field-user-select.php
@@ -69,9 +69,16 @@ class Shortcode_UI_Field_User_Select {
 	}
 
 	/**
-	 * Output styles and templates used by user select field.
+	 * Prepare to output the templates required for this field in the footer.
 	 */
 	public function action_shortcode_ui_loaded_editor() {
+		add_action( 'admin_print_footer_scripts', array( $this, 'output_templates' ) );
+    }
+
+	/**
+	 * Output templates used by user select field.
+	 */
+	public function output_templates() {
 		?>
 
 		<script type="text/html" id="tmpl-shortcode-ui-field-user-select">


### PR DESCRIPTION
As noted in #806, the pattern used for many of the Shortcake attribute fields which output custom field templates is to output those templates on the `shortcode_ui_loaded_editor` hook. In WP 5.0 with the block editor active, this hook fires before the page output is begun, which causes these script templates to be spit out before the opening <doctype> tag, causing all kinds of ruckus with the browser layout.

Specifically, any output before the <doctype> declaration forces browsers into quirks mode, which renders the flex layout required for the Gutenberg editor incorrectly. In practive this was causing meta boxes to float awkwardly over editor content.

This fixes the problem by, instead of outputting the templates on the `shortcode_ui_loaded_editor` hook, instead attaching a hook to a later action to output these templates in the admin footer.