### PR TITLE
Fixes error in Gutenberg Gallery Block when wpActiveEditor is not defined

### DIFF
--- a/js/build/shortcode-ui.js
+++ b/js/build/shortcode-ui.js
@@ -49,7 +49,7 @@ var MediaController = wp.media.controller.State.extend({
 			action: 'select',
 			search: null,
 			insertCallback: this.insertCallback,
-			editor: wpActiveEditor,
+			editor: window.wpActiveEditor ? window.wpActiveEditor : null,
 		});
 
 		this.props.on( 'change:action', this.refresh, this );

--- a/js/src/controllers/media-controller.js
+++ b/js/src/controllers/media-controller.js
@@ -12,7 +12,7 @@ var MediaController = wp.media.controller.State.extend({
 			action: 'select',
 			search: null,
 			insertCallback: this.insertCallback,
-			editor: wpActiveEditor,
+			editor: window.wpActiveEditor ? window.wpActiveEditor : null,
 		});
 
 		this.props.on( 'change:action', this.refresh, this );


### PR DESCRIPTION
When using Shortcake(master / 0.7.4) with Gutenberg(Core / 7.0.0), we ran into an issue where adding a Gallery block to a Post always fails with this error.

```
ReferenceError: "wpActiveEditor is not defined"
    initialize https://shortcake.test/wp-content/plugins/shortcode-ui/js/build/shortcode-ui.js?ver=0.7.4:52
    Model Backbone
    constructor https://shortcake.test/wp-includes/js/media-views.min.js?ver=5.3:1
    i Backbone
    initialize https://shortcake.test/wp-content/plugins/shortcode-ui/js/build/shortcode-ui.js?ver=0.7.4:1587
    Backbone 2
    constructor https://shortcake.test/wp-includes/js/media-views.min.js?ver=5.3:1
    Backbone 6
    value https://shortcake.test/wp-content/plugins/gutenberg/build/media-utils/index.js?ver=6ba6b7533b7a4318f507617d849aa205:1
    t https://shortcake.test/wp-content/plugins/gutenberg/build/media-utils/index.js?ver=6ba6b7533b7a4318f507617d849aa205:1
    Ag https://shortcake.test/wp-content/plugins/gutenberg/vendor/react-dom.min.b694e242.js?ver=16.9.0:63
    Vg https://shortcake.test/wp-content/plugins/gutenberg/vendor/react-dom.min.b694e242.js?ver=16.9.0:89
    ph https://shortcake.test/wp-content/plugins/gutenberg/vendor/react-dom.min.b694e242.js?ver=16.9.0:217
    lh https://shortcake.test/wp-content/plugins/gutenberg/vendor/react-dom.min.b694e242.js?ver=16.9.0:126
    O https://shortcake.test/wp-content/plugins/gutenberg/vendor/react-dom.min.b694e242.js?ver=16.9.0:121
    ze https://shortcake.test/wp-content/plugins/gutenberg/vendor/react-dom.min.b694e242.js?ver=16.9.0:118
    mg https://shortcake.test/wp-content/plugins/gutenberg/vendor/react-dom.min.b694e242.js?ver=16.9.0:53
    unstable_runWithPriority https://shortcake.test/wp-content/plugins/gutenberg/vendor/react.min.0212dc62.js?ver=16.9.0:26
    Ma https://shortcake.test/wp-content/plugins/gutenberg/vendor/react-dom.min.b694e242.js?ver=16.9.0:52
    mg https://shortcake.test/wp-content/plugins/gutenberg/vendor/react-dom.min.b694e242.js?ver=16.9.0:52
    V https://shortcake.test/wp-content/plugins/gutenberg/vendor/react-dom.min.b694e242.js?ver=16.9.0:52
    Be https://shortcake.test/wp-content/plugins/gutenberg/vendor/react-dom.min.b694e242.js?ver=16.9.0:119
    xi https://shortcake.test/wp-content/plugins/gutenberg/vendor/react-dom.min.b694e242.js?ver=16.9.0:39
react-dom.min.b694e242.js:103:487

```

This PR fixes the error by first checking if `wpActiveEditor` is defined.