### PR TITLE
VIP linter fixes

### DIFF
--- a/inc/fields/class-shortcode-ui-field-post-select.php
+++ b/inc/fields/class-shortcode-ui-field-post-select.php
@@ -93,8 +93,13 @@ class Shortcode_UI_Field_Post_Select {
 		$nonce               = isset( $_GET['nonce'] ) ? sanitize_text_field( $_GET['nonce'] ) : null;
 		$requested_shortcode = isset( $_GET['shortcode'] ) ? sanitize_text_field( $_GET['shortcode'] ) : null;
 		$requested_attr      = isset( $_GET['attr'] ) ? sanitize_text_field( $_GET['attr'] ) : null;
-		$include             = isset( $_GET['include'] ) ? $_GET['include'] : array();
+		
 
+		$include = filter_input( INPUT_GET, 'include', FILTER_SANITIZE_NUMBER_INT, FILTER_REQUIRE_ARRAY );
+		if ( ! is_array( $include ) ) {
+			$include = (array) explode( ',', filter_input( INPUT_GET, 'include', FILTER_SANITIZE_STRING ) );
+		}
+		$include = array_map( 'intval', $include );
 
 		$response = array(
 			'items'          => array(),
@@ -139,11 +144,7 @@ class Shortcode_UI_Field_Post_Select {
 		}
 
 		if ( ! empty( $include ) ) {
-			$post__in        = is_array( $include ) ? $include : (array) explode( ',', sanitize_text_field( $include ) );
-			$post__in        = array_map( 'intval', $post__in );
-			unset( $include );
-
-			$query_args['post__in']            = $post__in;
+			$query_args['post__in']            = $include;
 			$query_args['orderby']             = 'post__in';
 			$query_args['ignore_sticky_posts'] = true;
 		}

--- a/inc/fields/class-shortcode-ui-field-post-select.php
+++ b/inc/fields/class-shortcode-ui-field-post-select.php
@@ -98,7 +98,7 @@ class Shortcode_UI_Field_Post_Select {
 		if ( ! is_array( $include ) ) {
 			$include = (array) explode( ',', filter_input( INPUT_GET, 'include', FILTER_SANITIZE_STRING ) );
 		}
-		$include = array_map( 'intval', $include );
+		$include = array_filter( array_map( 'intval', $include ) );
 
 		$response = array(
 			'items'          => array(),

--- a/inc/fields/class-shortcode-ui-field-post-select.php
+++ b/inc/fields/class-shortcode-ui-field-post-select.php
@@ -93,7 +93,7 @@ class Shortcode_UI_Field_Post_Select {
 		$nonce               = isset( $_GET['nonce'] ) ? sanitize_text_field( $_GET['nonce'] ) : null;
 		$requested_shortcode = isset( $_GET['shortcode'] ) ? sanitize_text_field( $_GET['shortcode'] ) : null;
 		$requested_attr      = isset( $_GET['attr'] ) ? sanitize_text_field( $_GET['attr'] ) : null;
-		$include             = isset( $_GET['include']) ? $_GET['input'] : array();
+		$include             = isset( $_GET['include'] ) ? $_GET['include'] : array();
 
 
 		$response = array(

--- a/inc/fields/class-shortcode-ui-field-post-select.php
+++ b/inc/fields/class-shortcode-ui-field-post-select.php
@@ -93,7 +93,6 @@ class Shortcode_UI_Field_Post_Select {
 		$nonce               = isset( $_GET['nonce'] ) ? sanitize_text_field( $_GET['nonce'] ) : null;
 		$requested_shortcode = isset( $_GET['shortcode'] ) ? sanitize_text_field( $_GET['shortcode'] ) : null;
 		$requested_attr      = isset( $_GET['attr'] ) ? sanitize_text_field( $_GET['attr'] ) : null;
-		
 
 		$include = filter_input( INPUT_GET, 'include', FILTER_SANITIZE_NUMBER_INT, FILTER_REQUIRE_ARRAY );
 		if ( ! is_array( $include ) ) {

--- a/inc/fields/class-shortcode-ui-field-post-select.php
+++ b/inc/fields/class-shortcode-ui-field-post-select.php
@@ -93,6 +93,8 @@ class Shortcode_UI_Field_Post_Select {
 		$nonce               = isset( $_GET['nonce'] ) ? sanitize_text_field( $_GET['nonce'] ) : null;
 		$requested_shortcode = isset( $_GET['shortcode'] ) ? sanitize_text_field( $_GET['shortcode'] ) : null;
 		$requested_attr      = isset( $_GET['attr'] ) ? sanitize_text_field( $_GET['attr'] ) : null;
+		$include             = isset( $_GET['include']) ? $_GET['input'] : array();
+
 
 		$response = array(
 			'items'          => array(),
@@ -136,9 +138,12 @@ class Shortcode_UI_Field_Post_Select {
 			$query_args['s'] = sanitize_text_field( $_GET['s'] );
 		}
 
-		if ( ! empty( $_GET['include'] ) ) {
-			$post__in                          = is_array( $_GET['include'] ) ? $_GET['include'] : explode( ',', $_GET['include'] );
-			$query_args['post__in']            = array_map( 'intval', $post__in );
+		if ( ! empty( $include ) ) {
+			$post__in        = is_array( $include ) ? $include : (array) explode( ',', sanitize_text_field( $include ) );
+			$post__in        = array_map( 'intval', $post__in );
+			unset( $include );
+
+			$query_args['post__in']            = $post__in;
 			$query_args['orderby']             = 'post__in';
 			$query_args['ignore_sticky_posts'] = true;
 		}

--- a/inc/fields/class-shortcode-ui-field-term-select.php
+++ b/inc/fields/class-shortcode-ui-field-term-select.php
@@ -110,7 +110,7 @@ class Shortcode_UI_Field_Term_Select {
 		if ( ! is_array( $include ) ) {
 			$include = (array) explode( ',', filter_input( INPUT_GET, 'include', FILTER_SANITIZE_STRING ) );
 		}
-		$include = array_map( 'intval', $include );
+		$include = array_filter( array_map( 'intval', $include ) );
 
 		$response = array(
 			'items'          => array(),

--- a/inc/fields/class-shortcode-ui-field-term-select.php
+++ b/inc/fields/class-shortcode-ui-field-term-select.php
@@ -99,11 +99,13 @@ class Shortcode_UI_Field_Term_Select {
 	 */
 	public function action_wp_ajax_shortcode_ui_term_field() {
 
+		$args                = array();
 		$nonce               = isset( $_GET['nonce'] ) ? sanitize_text_field( $_GET['nonce'] ) : null;
 		$requested_shortcode = isset( $_GET['shortcode'] ) ? sanitize_text_field( $_GET['shortcode'] ) : null;
 		$requested_attr      = isset( $_GET['attr'] ) ? sanitize_text_field( $_GET['attr'] ) : null;
 		$page                = isset( $_GET['page'] ) ? absint( $_GET['page'] ) : null;
 		$search              = isset( $_GET['s'] ) ? sanitize_text_field( $_GET['s'] ) : '';
+		$include             = isset( $_GET['include']) ? $_GET['input'] : array();
 
 		$response = array(
 			'items'          => array(),
@@ -142,10 +144,13 @@ class Shortcode_UI_Field_Term_Select {
 		$args['hide_empty'] = false;
 		$args['number']     = 10;
 
-		if ( ! empty( $_GET['include'] ) ) {
-			$term__in        = is_array( $_GET['include'] ) ? $_GET['include'] : explode( ',', $_GET['include'] );
+		if ( ! empty( $include ) ) {
+			$term__in        = is_array( $include ) ? $include : (array) explode( ',', sanitize_text_field( $include ) );
+			$term__in        = array_map( 'intval', $term__in );
+			unset( $include );
+
 			$args['number']  = count( $term__in );
-			$args['include'] = array_map( 'intval', $term__in );
+			$args['include'] = $term__in;
 			$args['orderby'] = 'tag__in';
 		}
 

--- a/inc/fields/class-shortcode-ui-field-term-select.php
+++ b/inc/fields/class-shortcode-ui-field-term-select.php
@@ -105,7 +105,7 @@ class Shortcode_UI_Field_Term_Select {
 		$requested_attr      = isset( $_GET['attr'] ) ? sanitize_text_field( $_GET['attr'] ) : null;
 		$page                = isset( $_GET['page'] ) ? absint( $_GET['page'] ) : null;
 		$search              = isset( $_GET['s'] ) ? sanitize_text_field( $_GET['s'] ) : '';
-		$include             = isset( $_GET['include']) ? $_GET['input'] : array();
+		$include             = isset( $_GET['include'] ) ? $_GET['include'] : array();
 
 		$response = array(
 			'items'          => array(),

--- a/inc/fields/class-shortcode-ui-field-term-select.php
+++ b/inc/fields/class-shortcode-ui-field-term-select.php
@@ -105,7 +105,12 @@ class Shortcode_UI_Field_Term_Select {
 		$requested_attr      = isset( $_GET['attr'] ) ? sanitize_text_field( $_GET['attr'] ) : null;
 		$page                = isset( $_GET['page'] ) ? absint( $_GET['page'] ) : null;
 		$search              = isset( $_GET['s'] ) ? sanitize_text_field( $_GET['s'] ) : '';
-		$include             = isset( $_GET['include'] ) ? $_GET['include'] : array();
+
+		$include = filter_input( INPUT_GET, 'include', FILTER_SANITIZE_NUMBER_INT, FILTER_REQUIRE_ARRAY );
+		if ( ! is_array( $include ) ) {
+			$include = (array) explode( ',', filter_input( INPUT_GET, 'include', FILTER_SANITIZE_STRING ) );
+		}
+		$include = array_map( 'intval', $include );
 
 		$response = array(
 			'items'          => array(),
@@ -145,12 +150,8 @@ class Shortcode_UI_Field_Term_Select {
 		$args['number']     = 10;
 
 		if ( ! empty( $include ) ) {
-			$term__in        = is_array( $include ) ? $include : (array) explode( ',', sanitize_text_field( $include ) );
-			$term__in        = array_map( 'intval', $term__in );
-			unset( $include );
-
-			$args['number']  = count( $term__in );
-			$args['include'] = $term__in;
+			$args['number']  = count( $include );
+			$args['include'] = $include;
 			$args['orderby'] = 'tag__in';
 		}
 


### PR DESCRIPTION
A couple of issues were highlighted by the wp linter bot.

Sanitizes unsafe $_GET['include'] use and defines $args as an empty array before using it.

Tested against `?include=12,23a`, `?include[]=12&include[]=23a` and without parameter.