### PR TITLE
Handle post_type not being an array

### DIFF
--- a/inc/class-shortcode-ui.php
+++ b/inc/class-shortcode-ui.php
@@ -6,6 +6,14 @@
 class Shortcode_UI {
 
 	/**
+	 * Plugin version.
+	 *
+	 * @access private
+	 * @var string
+	 */
+	private $plugin_version;
+
+	/**
 	 * Path to the plugin directory.
 	 *
 	 * @access private

--- a/inc/fields/class-shortcode-ui-field-post-select.php
+++ b/inc/fields/class-shortcode-ui-field-post-select.php
@@ -145,7 +145,7 @@ class Shortcode_UI_Field_Post_Select {
 
 		$query                  = new WP_Query( $query_args );
 		$post_types             = $query->get( 'post_type' );
-		$is_multiple_post_types = count( $post_types ) > 1 || 'any' === $post_types;
+		$is_multiple_post_types = ( is_array( $post_types ) && count( $post_types ) > 1 ) || 'any' === $post_types;
 
 		foreach ( $query->posts as $post_id ) {
 			$post_type     = get_post_type( $post_id );


### PR DESCRIPTION
Ensure that `$post_types` is an array to prevent a fatal PHP (the fatal error applies to PHP 8):

```
Fatal error: Uncaught Error: count(): Argument #1 ($value) must be of type Countable|array, string given
in ...

Call stack:

Shortcode_UI_Field_Post_Select::action_wp_ajax_shortcode_ui_post_field()
wp-includes/class-wp-hook.php:307
WP_Hook::apply_filters()
wp-includes/class-wp-hook.php:331
WP_Hook::do_action()
wp-includes/plugin.php:476
do_action()
wp-admin/admin-ajax.php:187
Query Monitor
There has been a critical error on this website.
```